### PR TITLE
feat(env): detect Cloud Run as production via K_SERVICE

### DIFF
--- a/env.go
+++ b/env.go
@@ -4,7 +4,8 @@ import (
 	"os"
 )
 
-// IsInProd indicates if app is running in APP ENGINE
+// IsInProd indicates if app is running in a managed cloud runtime (App Engine or Cloud Run)
 func IsInProd() bool {
-	return os.Getenv("GAE_APPLICATION") != ""
+	return os.Getenv("GAE_APPLICATION") != "" || // App Engine
+		os.Getenv("K_SERVICE") != "" // Cloud Run
 }

--- a/env_test.go
+++ b/env_test.go
@@ -6,20 +6,29 @@ import (
 )
 
 func TestIsInProd(t *testing.T) {
-	const envVar = "GAE_APPLICATION"
+	const gaeAppVar = "GAE_APPLICATION" // set by App Engine
+	const cloudRunVar = "K_SERVICE"     // set by Cloud Run
 
-	original := os.Getenv(envVar)
-	t.Cleanup(func() {
-		_ = os.Setenv(envVar, original)
-	})
-
-	_ = os.Setenv(envVar, "")
-	if IsInProd() {
-		t.Error("expected IsInProd() == false when GAE_APPLICATION is empty")
+	for _, envVar := range []string{gaeAppVar, cloudRunVar} {
+		original := os.Getenv(envVar)
+		t.Cleanup(func() {
+			_ = os.Setenv(envVar, original)
+		})
+		_ = os.Setenv(envVar, "")
 	}
 
-	_ = os.Setenv(envVar, "s~my-app")
+	if IsInProd() {
+		t.Error("expected IsInProd() == false when neither GAE_APPLICATION nor K_SERVICE is set")
+	}
+
+	_ = os.Setenv(gaeAppVar, "s~my-app")
 	if !IsInProd() {
 		t.Error("expected IsInProd() == true when GAE_APPLICATION is set")
+	}
+	_ = os.Setenv(gaeAppVar, "")
+
+	_ = os.Setenv(cloudRunVar, "sneat-app")
+	if !IsInProd() {
+		t.Error("expected IsInProd() == true when K_SERVICE is set")
 	}
 }


### PR DESCRIPTION
## What
`IsInProd()` now returns true on Cloud Run (via the auto-set `K_SERVICE` env var), in addition to App Engine (`GAE_APPLICATION`).

## Why
Services on Cloud Run were falling back to the local-dev environment, so the bot registry demanded `SNEAT_TG_DEV_BOTS` and rejected production bots (e.g. `DataTugBot` returned "unknown bot" / "SNEAT_TG_DEV_BOTS is not set"). Cloud Run is production; detect it as such.

## Test
Updated `TestIsInProd` to cover both `GAE_APPLICATION` and `K_SERVICE`, and to clear both before the negative assertion. `go test ./...` and `go vet ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)