### PR TITLE
feat(extension): declare known hosts for CORS

### DIFF
--- a/extension/config.go
+++ b/extension/config.go
@@ -14,6 +14,10 @@ type Config interface {
 	internal()
 	ID() coretypes.ExtID
 	Register(args RegistrationArgs)
+	// KnownHosts returns the extra hosts (e.g. "gameboard.live") whose origins
+	// this extension's API server must accept for CORS. The scheme is derived by
+	// the security package (see security.AddKnownHosts).
+	KnownHosts() []string
 }
 
 type RegistrationArgs interface {
@@ -58,12 +62,15 @@ var _ Config = (*config)(nil)
 // config implements Config interface
 type config struct {
 	id                   coretypes.ExtID
+	knownHosts           []string
 	registerRoutes       []func(handle HTTPHandleFunc)
 	registerDelays       []func(mustRegisterFunc func(key string, i any) delaying.Delayer)
 	registerNotificators []func(createNotification CreateNotificationFunc)
 }
 
 func (m *config) internal() {}
+
+func (m *config) KnownHosts() []string { return m.knownHosts }
 
 func (m *config) Register(args RegistrationArgs) {
 
@@ -104,6 +111,16 @@ func NewExtension(id coretypes.ExtID, options ...Option) Config {
 		option(m)
 	}
 	return m
+}
+
+// RegisterKnownHosts declares extra hosts (e.g. "gameboard.live") whose origins
+// this extension's API server must accept for CORS. Hosts are exposed via
+// Config.KnownHosts() and applied by the server at module registration time.
+func RegisterKnownHosts(hosts ...string) Option {
+	return func(m Config) {
+		c := m.(*config)
+		c.knownHosts = append(c.knownHosts, hosts...)
+	}
 }
 
 func RegisterRoutes(registerRoutes func(handle HTTPHandleFunc)) Option {

--- a/extension/config_test.go
+++ b/extension/config_test.go
@@ -54,6 +54,19 @@ func TestRegisterRoutes_composes(t *testing.T) {
 	assert.Equal(t, []int{1, 2}, calls, "both RegisterRoutes options must be called in order")
 }
 
+func TestRegisterKnownHosts_composes(t *testing.T) {
+	m := NewExtension("test",
+		RegisterKnownHosts("a.example"),
+		RegisterKnownHosts("b.example", "c.example"),
+	)
+	assert.Equal(t, []string{"a.example", "b.example", "c.example"}, m.KnownHosts())
+}
+
+func TestKnownHosts_emptyByDefault(t *testing.T) {
+	m := NewExtension("test")
+	assert.Empty(t, m.KnownHosts())
+}
+
 func TestRegisterDelays_composes(t *testing.T) {
 	var calls []int
 	d1 := func(mustRegisterFunc func(key string, i any) delaying.Delayer) { calls = append(calls, 1) }


### PR DESCRIPTION
## Why

Extensions whose SPA calls the shared API server cross-origin (e.g. GameBoard.live at `https://gameboard.live/app` → `api.sneat.ws`) were blocked by CORS because their host was not on the `security` allowlist. Previously the only way to add a host was the flat `extraKnownHosts` list passed to `InitServer`.

## What

Extend the extension contract so each extension declares the hosts its API server must accept:

- `RegisterKnownHosts(hosts ...string)` functional option (mirrors `RegisterRoutes`)
- `Config.KnownHosts() []string` on the interface

The consuming server (sneat-go) reads `KnownHosts()` at module-registration time and applies them via `security.AddKnownHosts`. Hosts are bare (e.g. `gameboard.live`); the scheme is derived by the security package.

Adding `KnownHosts()` to `Config` is non-breaking: the interface has an unexported `internal()` marker, so it cannot be implemented outside this package.

## Tests

`go test ./extension/... ./security/...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)