### PR TITLE
feat(coretypes): add SpaceTypeSystem space type

### DIFF
--- a/coretypes/space_type.go
+++ b/coretypes/space_type.go
@@ -25,6 +25,10 @@ const (
 
 	// SpaceTypeClub is a "club" space type
 	SpaceTypeClub SpaceType = "club"
+
+	// SpaceTypeSystem is a platform-owned "system" space type for shared,
+	// cross-user records that are not tied to per-user membership.
+	SpaceTypeSystem SpaceType = "system"
 )
 
 const FamilyWeekSpaceRef = SpaceRef(SpaceTypeFamily)
@@ -84,7 +88,7 @@ func NewWeakSpaceRef(spaceType SpaceType) SpaceRef {
 // IsValidSpaceType checks if space has a valid/known type
 func IsValidSpaceType(v SpaceType) bool {
 	switch v {
-	case SpaceTypeFamily, SpaceTypePrivate, SpaceTypeGroup, SpaceTypeCompany, SpaceTypeSpace, SpaceTypeClub:
+	case SpaceTypeFamily, SpaceTypePrivate, SpaceTypeGroup, SpaceTypeCompany, SpaceTypeSpace, SpaceTypeClub, SpaceTypeSystem:
 		return true
 	default:
 		return false

--- a/coretypes/space_type_test.go
+++ b/coretypes/space_type_test.go
@@ -15,6 +15,7 @@ func TestIsValidSpaceType(t *testing.T) {
 		want bool
 	}{
 		{"SpaceTypePrivate", args{SpaceTypePrivate}, true},
+		{"SpaceTypeSystem", args{SpaceTypeSystem}, true},
 		{"EmptySpaceType", args{""}, false},
 		{"InvalidSpaceType", args{"Foo"}, false},
 	}


### PR DESCRIPTION
## What

Adds a platform-owned `SpaceTypeSystem` (`"system"`) to `coretypes.SpaceType`, accepted by `IsValidSpaceType`.

## Why

First task of the **system-space-type** plan (spec: `sneat-co/sneat-specs` → `spec/plans/system-space-type.md`). A System space is the home for an extension's shared, cross-user records whose writes are open to any authenticated user (membership not required), with per-record authorization delegated to the owning extension. This enum value is the foundation the spaceus access-check changes (in `sneat-core-modules`) branch on next; it must be released first.

## Changes

- `coretypes/space_type.go`: new typed const `SpaceTypeSystem SpaceType = "system"` + `IsValidSpaceType` case.
- `coretypes/space_type_test.go`: test row asserting `IsValidSpaceType(SpaceTypeSystem) == true`.

`go test ./coretypes/` and `go build ./...` pass.

Verifies: system-space-type#ac:type-accepted-by-validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)