### PR TITLE
twiliosms: shared ecosystem Twilio SMS kernel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/strongo/decimal v0.1.1 // indirect
+	github.com/strongo/gotwilio v0.0.0-20160123000810-f024bbefe80f // indirect
 	github.com/strongo/random v0.0.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/strongo/delaying v0.2.1 h1:vpugNAmvwF81ZcICARgAzMWjACi3UXDSTLxfe9fB/4
 github.com/strongo/delaying v0.2.1/go.mod h1:6PnWp2IL3UDo7tQyFVIOxBiIiHSj0eVZ6VfrleGNjzA=
 github.com/strongo/delaying v0.2.2 h1:c+uqQWD0h7TTLJNpMiCKchw9y4z18d/Sk68Lv77UnnU=
 github.com/strongo/delaying v0.2.2/go.mod h1:6PnWp2IL3UDo7tQyFVIOxBiIiHSj0eVZ6VfrleGNjzA=
+github.com/strongo/gotwilio v0.0.0-20160123000810-f024bbefe80f h1:nLD1340Ys0nXjVurNp5O/7CoDuZTo++7qydiikwxKho=
+github.com/strongo/gotwilio v0.0.0-20160123000810-f024bbefe80f/go.mod h1:AOBNKIosqbvHdXh8+u8QBWz7xeHz9sjDS0zVJjspzN8=
 github.com/strongo/logus v0.4.0 h1:EdwNafWX1eGWvPqMvu3gHVqXtBOUvV9KWbxm6tCU+dU=
 github.com/strongo/logus v0.4.0/go.mod h1:sd8gjJklqGQAg+Q0mlP5MWgzguAuxR25YYFSkfVOPdc=
 github.com/strongo/logus v0.4.1 h1:jEkcT5JzawDYjexRVHkCQiG4tv6Bm2a/c/ZdLk0IPqM=

--- a/twiliosms/twiliosms.go
+++ b/twiliosms/twiliosms.go
@@ -1,0 +1,142 @@
+// Package twiliosms is the ecosystem's single shared Twilio SMS-sending kernel.
+//
+// It is the ONE place the Sneat ecosystem builds a Twilio client, applies the
+// +8→+7 phone-number fixup, and classifies a Twilio exception as permanent vs
+// transient. Both the sneat-go notificator SMS provider
+// (pkg/notificator/channels4notificator/twilio4notificator) and the debtus bot's
+// sms package delegate here, so there is exactly one copy of this logic. Previously
+// the fixup + classification were duplicated: originally in debtus's
+// debtus/sms/send.go, then ported (copied) into the notificator provider. This
+// package collapses both onto a shared kernel.
+//
+// It lives in sneat-go-core — the one module BOTH sneat-go (the host) and the
+// debtus/backend extension already depend on — because an extension module must
+// not import the host sneat-go (import-cycle + dependency-weight in its
+// public-only CI). A neutral low-level home is the only thing both can import.
+//
+// The package is credential-agnostic about identity: callers pass Credentials.
+// The generalized env var names (Env*) and CredentialsFromEnv give every consumer
+// the SAME ecosystem-wide Twilio account/number when they read the environment —
+// which is how debtus now sends from the shared Sneat Twilio identity rather than
+// its own. A consumer that needs a different identity (e.g. debtus's Twilio test
+// sandbox, or its own delivery-status webhook) just builds Credentials itself.
+package twiliosms
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/strongo/gotwilio"
+)
+
+// Generalized ecosystem Twilio env var names. Flat naming matching
+// env_variables_template.yaml (AWS_*, ANTHROPIC_*, TMDB_*); deliberately NOT
+// debtus's historical TWILIO_LIVE_* names — a single set of names means a single
+// shared identity across the ecosystem.
+const (
+	EnvAccountSID        = "TWILIO_ACCOUNT_SID"         // required
+	EnvAuthToken         = "TWILIO_AUTH_TOKEN"          // required
+	EnvFromNumber        = "TWILIO_FROM_NUMBER"         // required (E.164 sender number)
+	EnvApplicationSID    = "TWILIO_APPLICATION_SID"     // optional
+	EnvStatusCallbackURL = "TWILIO_STATUS_CALLBACK_URL" // optional (delivery-status webhook)
+)
+
+// Credentials carries everything needed to send an SMS: the account identity, the
+// sender number, and the optional application SID + delivery-status callback URL.
+type Credentials struct {
+	AccountSID        string
+	AuthToken         string
+	FromNumber        string
+	ApplicationSID    string
+	StatusCallbackURL string
+}
+
+// CredentialsFromEnv reads the generalized TWILIO_* env vars. ok is false (and
+// Credentials zero) when any REQUIRED credential (account SID, auth token, from
+// number) is absent, so a caller can leave its SMS path unconfigured rather than
+// building a broken sender. It never panics and never makes a network call.
+func CredentialsFromEnv(getenv func(string) string) (creds Credentials, ok bool) {
+	accountSID := strings.TrimSpace(getenv(EnvAccountSID))
+	authToken := strings.TrimSpace(getenv(EnvAuthToken))
+	fromNumber := strings.TrimSpace(getenv(EnvFromNumber))
+	if accountSID == "" || authToken == "" || fromNumber == "" {
+		return Credentials{}, false
+	}
+	return Credentials{
+		AccountSID:        accountSID,
+		AuthToken:         authToken,
+		FromNumber:        fromNumber,
+		ApplicationSID:    strings.TrimSpace(getenv(EnvApplicationSID)),
+		StatusCallbackURL: strings.TrimSpace(getenv(EnvStatusCallbackURL)),
+	}, true
+}
+
+// Client is the subset of gotwilio.Twilio this package uses. It is an interface
+// so consumers' tests can inject a fake without making live Twilio calls (the
+// production client is built by NewClient).
+type Client interface {
+	SendSMS(from, to, body, statusCallback, applicationSid string) (*gotwilio.SmsResponse, *gotwilio.Exception, error)
+}
+
+// NewClient builds the production gotwilio client for the given credentials. When
+// httpClient is nil gotwilio uses http.DefaultClient. It never makes a network
+// call, so it is safe to build eagerly.
+func NewClient(creds Credentials, httpClient *http.Client) Client {
+	return gotwilio.NewTwilioClientCustomHTTP(creds.AccountSID, creds.AuthToken, httpClient)
+}
+
+// Send sends an SMS through client using creds' FromNumber / StatusCallbackURL /
+// ApplicationSID, applying the +8→+7 fixup (see below). It returns gotwilio's
+// response and exception VERBATIM so each caller can build its own result shape
+// (the notificator maps to a permanent/transient flag via IsPermanentException;
+// debtus surfaces the exception to its bot UI via TwilioExceptionToMessage).
+//
+// The +8→+7 fixup: some "+8..." numbers are really "+7..." (Russia/Kazakhstan)
+// and Twilio rejects them with error 21211; on that exact case (12-digit, "+8"
+// prefix) Send retries once with the corrected prefix before giving up.
+func Send(client Client, creds Credentials, to, text string) (*gotwilio.SmsResponse, *gotwilio.Exception, error) {
+	resp, ex, err := client.SendSMS(creds.FromNumber, to, text, creds.StatusCallbackURL, creds.ApplicationSID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if ex != nil && ex.Code == 21211 && len(to) == 12 && strings.HasPrefix(to, "+8") {
+		corrected := strings.Replace(to, "+8", "+7", 1)
+		return client.SendSMS(creds.FromNumber, corrected, text, creds.StatusCallbackURL, creds.ApplicationSID)
+	}
+	return resp, ex, err
+}
+
+// permanentCodes are the Twilio error codes that mean "this number will never
+// accept this message" — a permanent classification lets a caller advance a
+// fallback chain instead of retrying a doomed send.
+//
+//	21211 — invalid phone number          https://www.twilio.com/docs/errors/21211
+//	21614 — not an SMS-capable/mobile no.  https://www.twilio.com/docs/errors/21614
+//	21612 — not reachable from From no.    https://www.twilio.com/docs/errors/21612
+//	21408 — SMS not enabled for region     https://www.twilio.com/docs/errors/21408
+//	21610 — From/To pair is blacklisted    https://www.twilio.com/docs/errors/21610
+var permanentCodes = map[int]bool{
+	21211: true,
+	21614: true,
+	21612: true,
+	21408: true,
+	21610: true,
+}
+
+// IsPermanentException classifies a Twilio exception as permanent (true) or
+// transient (false). Permanent for the known bad-number codes above, and for any
+// generic 4xx client error (which the same retry will never fix) EXCEPT HTTP 429
+// rate-limiting. Transient for 429, 5xx and anything else (network hiccups),
+// which the caller should retry. A nil exception is not permanent.
+func IsPermanentException(ex *gotwilio.Exception) bool {
+	if ex == nil {
+		return false
+	}
+	if permanentCodes[ex.Code] {
+		return true
+	}
+	if ex.Status >= 400 && ex.Status < 500 && ex.Status != http.StatusTooManyRequests {
+		return true
+	}
+	return false
+}

--- a/twiliosms/twiliosms_test.go
+++ b/twiliosms/twiliosms_test.go
@@ -1,0 +1,164 @@
+package twiliosms
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/strongo/gotwilio"
+)
+
+// fakeClient records calls and returns scripted results per call index.
+type fakeClient struct {
+	calls   []string // "to" of each SendSMS call, in order
+	results []struct {
+		resp *gotwilio.SmsResponse
+		ex   *gotwilio.Exception
+		err  error
+	}
+}
+
+func (f *fakeClient) SendSMS(_, to, _, _, _ string) (*gotwilio.SmsResponse, *gotwilio.Exception, error) {
+	i := len(f.calls)
+	f.calls = append(f.calls, to)
+	if i >= len(f.results) {
+		return nil, nil, nil
+	}
+	r := f.results[i]
+	return r.resp, r.ex, r.err
+}
+
+func TestCredentialsFromEnv(t *testing.T) {
+	full := map[string]string{
+		EnvAccountSID:        "AC123",
+		EnvAuthToken:         "tok",
+		EnvFromNumber:        "+15551230000",
+		EnvApplicationSID:    "AP1",
+		EnvStatusCallbackURL: "https://cb",
+	}
+	getenv := func(m map[string]string) func(string) string {
+		return func(k string) string { return m[k] }
+	}
+
+	creds, ok := CredentialsFromEnv(getenv(full))
+	if !ok {
+		t.Fatal("expected ok with full env")
+	}
+	if creds.AccountSID != "AC123" || creds.FromNumber != "+15551230000" || creds.ApplicationSID != "AP1" || creds.StatusCallbackURL != "https://cb" {
+		t.Errorf("unexpected creds: %+v", creds)
+	}
+
+	// Each required field missing → not ok.
+	for _, missing := range []string{EnvAccountSID, EnvAuthToken, EnvFromNumber} {
+		m := map[string]string{}
+		for k, v := range full {
+			m[k] = v
+		}
+		delete(m, missing)
+		if _, ok := CredentialsFromEnv(getenv(m)); ok {
+			t.Errorf("expected not-ok when %s is missing", missing)
+		}
+	}
+
+	// Whitespace-only required field is treated as missing.
+	m := map[string]string{EnvAccountSID: "  ", EnvAuthToken: "tok", EnvFromNumber: "+1"}
+	if _, ok := CredentialsFromEnv(getenv(m)); ok {
+		t.Error("expected not-ok when account SID is whitespace")
+	}
+}
+
+func TestSend_PlainSuccess(t *testing.T) {
+	client := &fakeClient{results: []struct {
+		resp *gotwilio.SmsResponse
+		ex   *gotwilio.Exception
+		err  error
+	}{
+		{resp: &gotwilio.SmsResponse{Sid: "SM1"}},
+	}}
+	creds := Credentials{FromNumber: "+15551230000"}
+	resp, ex, err := Send(client, creds, "+12025550100", "hi")
+	if err != nil || ex != nil || resp == nil || resp.Sid != "SM1" {
+		t.Fatalf("resp=%v ex=%v err=%v", resp, ex, err)
+	}
+	if len(client.calls) != 1 || client.calls[0] != "+12025550100" {
+		t.Errorf("calls=%v, want one call to the original number", client.calls)
+	}
+}
+
+func TestSend_TransportErrorNoRetry(t *testing.T) {
+	client := &fakeClient{results: []struct {
+		resp *gotwilio.SmsResponse
+		ex   *gotwilio.Exception
+		err  error
+	}{
+		{err: http.ErrHandlerTimeout},
+	}}
+	_, _, err := Send(client, Credentials{FromNumber: "+1"}, "+89991234567", "hi")
+	if err == nil {
+		t.Fatal("expected transport error propagated")
+	}
+	if len(client.calls) != 1 {
+		t.Errorf("transport error must not retry; calls=%v", client.calls)
+	}
+}
+
+func TestSend_Plus8ToPlus7Fixup(t *testing.T) {
+	client := &fakeClient{results: []struct {
+		resp *gotwilio.SmsResponse
+		ex   *gotwilio.Exception
+		err  error
+	}{
+		{ex: &gotwilio.Exception{Code: 21211, Message: "invalid"}}, // first: +8 rejected
+		{resp: &gotwilio.SmsResponse{Sid: "SM2"}},                  // retry with +7 succeeds
+	}}
+	resp, ex, err := Send(client, Credentials{FromNumber: "+1"}, "+89991234567", "hi")
+	if err != nil || ex != nil || resp == nil || resp.Sid != "SM2" {
+		t.Fatalf("resp=%v ex=%v err=%v", resp, ex, err)
+	}
+	if len(client.calls) != 2 {
+		t.Fatalf("expected 2 calls (original + fixup), got %v", client.calls)
+	}
+	if client.calls[1] != "+79991234567" {
+		t.Errorf("retry number = %q, want +79991234567", client.calls[1])
+	}
+}
+
+func TestSend_NoFixupWhenNotPlus8Or21211(t *testing.T) {
+	// 21211 but not a +8 12-digit number → no retry.
+	client := &fakeClient{results: []struct {
+		resp *gotwilio.SmsResponse
+		ex   *gotwilio.Exception
+		err  error
+	}{
+		{ex: &gotwilio.Exception{Code: 21211}},
+	}}
+	_, ex, _ := Send(client, Credentials{FromNumber: "+1"}, "+12025550100", "hi")
+	if ex == nil {
+		t.Error("expected the 21211 exception to be returned unretried")
+	}
+	if len(client.calls) != 1 {
+		t.Errorf("non-+8 number must not retry; calls=%v", client.calls)
+	}
+}
+
+func TestIsPermanentException(t *testing.T) {
+	tests := []struct {
+		name string
+		ex   *gotwilio.Exception
+		want bool
+	}{
+		{"nil", nil, false},
+		{"21211 bad number", &gotwilio.Exception{Code: 21211}, true},
+		{"21610 blacklist", &gotwilio.Exception{Code: 21610}, true},
+		{"generic 4xx", &gotwilio.Exception{Status: 400}, true},
+		{"429 rate limit is transient", &gotwilio.Exception{Status: http.StatusTooManyRequests}, false},
+		{"5xx transient", &gotwilio.Exception{Status: 503}, false},
+		{"unknown code, no status", &gotwilio.Exception{Code: 99999}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPermanentException(tt.ex); got != tt.want {
+				t.Errorf("IsPermanentException(%+v) = %v, want %v", tt.ex, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds `github.com/sneat-co/sneat-go-core/twiliosms` — the **one** place the Sneat ecosystem builds a Twilio client, applies the `+8→+7` phone-number fixup, and classifies a Twilio exception as permanent vs transient.

## Why here

This logic was **duplicated**: originally in debtus's `debtus/sms/send.go`, then copied into the sneat-go notificator SMS provider. Both will now delegate to this kernel, so there's exactly one copy. It lives in `sneat-go-core` because that's the one module **both** sneat-go (the host) and the `debtus/backend` extension already depend on — an extension must not import the host (import-cycle + dependency-weight in its public-only CI), so a neutral low-level home is the only thing both can import.

## API

- `Credentials` + generalized `Env*` var names (`TWILIO_ACCOUNT_SID`, …) + `CredentialsFromEnv` — a single set of env names means a single shared ecosystem Twilio identity when consumers read the environment.
- `Client` seam + `NewClient` (wraps `gotwilio.NewTwilioClientCustomHTTP`).
- `Send` (applies the `+8→+7` fixup; returns gotwilio's response/exception verbatim so each caller builds its own result shape).
- `IsPermanentException`.

Adds `gotwilio` as a core dependency (already used by both consumers).

## Follow-ups (this is step 1 of a 3-repo chain)

After this tags: sneat-go `twilio4notificator.Provider` delegates here; debtus `sms.SendSms` delegates here + its live path switches to the generalized `TWILIO_*` env (deleting its now-obsolete Twilio code); then sneat-go bumps its debtus dep.

## Test

`go build ./...` ✓  `go vet` ✓  `gofmt` ✓  `golangci-lint run ./twiliosms/` → 0 issues ✓  `go test ./twiliosms/` ✓ (fixup retry, no-retry cases, permanent/transient classification, env parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)