### PR TITLE
Add strict schema memory test database

### DIFF
--- a/sneatcoretesting/memory_db.go
+++ b/sneatcoretesting/memory_db.go
@@ -20,6 +20,16 @@ func NewMemoryDB() dal.DB {
 	return dalgo2memory.NewDB(dalgo2memory.WithNoReadsAfterWritesInTransaction())
 }
 
+// NewStrictSchemaMemoryDB creates an empty strict-schema in-memory database
+// for tests that must reject accesses to undeclared collections. It retains the
+// Firestore-compatible transaction ordering enforced by NewMemoryDB.
+func NewStrictSchemaMemoryDB() dal.DB {
+	return dalgo2memory.NewDB(
+		dalgo2memory.WithNoReadsAfterWritesInTransaction(),
+		dalgo2memory.WithSchema(false),
+	)
+}
+
 // ContextWithMemoryDB returns a child context with a new strict in-memory
 // database installed as its facade DB.
 func ContextWithMemoryDB(parent context.Context) (context.Context, dal.DB) {

--- a/sneatcoretesting/memory_db_test.go
+++ b/sneatcoretesting/memory_db_test.go
@@ -2,8 +2,10 @@ package sneatcoretesting_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/dal-go/dalgo/adapters/dalgo2memory"
 	"github.com/dal-go/dalgo/dal"
 	"github.com/dal-go/record"
 	"github.com/sneat-co/sneat-go-core/facade"
@@ -48,7 +50,19 @@ func TestNewMemoryDB_RejectsReadsAfterWrites(t *testing.T) {
 		}
 		return tx.Get(ctx, record.NewRecordWithData(key, new(struct{})))
 	})
+	if !errors.Is(err, dalgo2memory.ErrReadAfterWriteInTransaction) {
+		t.Fatalf("strict test DB read-after-write error = %v, want %v", err, dalgo2memory.ErrReadAfterWriteInTransaction)
+	}
+}
+
+func TestNewStrictSchemaMemoryDB_RejectsUndefinedCollections(t *testing.T) {
+	t.Parallel()
+	db := sneatcoretesting.NewStrictSchemaMemoryDB()
+	err := db.Get(context.Background(), record.NewRecordWithData(
+		record.NewKeyWithID("undefined", "record"),
+		new(struct{}),
+	))
 	if err == nil {
-		t.Fatal("strict test DB accepted a read after a write")
+		t.Fatal("strict schema test DB accepted an undefined collection")
 	}
 }


### PR DESCRIPTION
Adds sneatcoretesting.NewStrictSchemaMemoryDB for tests that require an empty strict schema while retaining no-reads-after-writes transaction enforcement.