### PR TITLE
refactor: isolate DB dependencies for parallel tests

### DIFF
--- a/facade/get_sneat_db.go
+++ b/facade/get_sneat_db.go
@@ -3,11 +3,88 @@ package facade
 import (
 	"context"
 	"fmt"
+	"sync"
+
 	"github.com/dal-go/dalgo/dal"
 )
 
-// GetSneatDB creates a new DB for a given context
-var GetSneatDB = func(ctx context.Context) (db dal.DB, err error) {
-	err = fmt.Errorf("%w: facade.GetSneatDB(context.Context) (dal.DB, error)", ErrNotInitialized)
+// SneatDBProvider resolves the database to use for a context.
+type SneatDBProvider func(ctx context.Context) (dal.DB, error)
+
+type sneatDBContextKey struct{}
+
+var (
+	defaultSneatDBProviderMu sync.RWMutex
+	defaultSneatDBProvider   SneatDBProvider = uninitializedSneatDBProvider
+	contextDBKey                             = sneatDBContextKey{}
+)
+
+// GetSneatDB returns a context override when one is present, otherwise it uses
+// the default provider configured by the application at startup.
+func GetSneatDB(ctx context.Context) (dal.DB, error) {
+	if provider, ok := ctx.Value(contextDBKey).(SneatDBProvider); ok {
+		return provider(ctx)
+	}
+
+	defaultSneatDBProviderMu.RLock()
+	provider := defaultSneatDBProvider
+	defaultSneatDBProviderMu.RUnlock()
+	return provider(ctx)
+}
+
+// WithSneatDB returns a child context that resolves db through GetSneatDB.
+// This is useful for request-scoped database selection and parallel tests.
+func WithSneatDB(ctx context.Context, db dal.DB) context.Context {
+	if db == nil {
+		panic("facade.WithSneatDB: nil DB")
+	}
+	return WithSneatDBProvider(ctx, func(context.Context) (dal.DB, error) {
+		return db, nil
+	})
+}
+
+// WithSneatDBProvider returns a child context that resolves its database using
+// provider. Unlike changing the default provider, this is safe in parallel
+// tests and allows testing provider failures.
+func WithSneatDBProvider(ctx context.Context, provider SneatDBProvider) context.Context {
+	if ctx == nil {
+		panic("facade.WithSneatDBProvider: nil context")
+	}
+	if provider == nil {
+		panic("facade.WithSneatDBProvider: nil provider")
+	}
+	return context.WithValue(ctx, contextDBKey, provider)
+}
+
+// SetDefaultSneatDBProvider replaces the application-wide fallback provider.
+// Applications should call this only while wiring dependencies at startup;
+// tests should use WithSneatDB instead.
+func SetDefaultSneatDBProvider(provider SneatDBProvider) {
+	if provider == nil {
+		panic("facade.SetDefaultSneatDBProvider: nil provider")
+	}
+	defaultSneatDBProviderMu.Lock()
+	defaultSneatDBProvider = provider
+	defaultSneatDBProviderMu.Unlock()
+}
+
+// UpdateDefaultSneatDBProvider atomically decorates or replaces the current
+// application-wide provider. It is intended for startup wiring such as adding
+// a cache around the primary database provider.
+func UpdateDefaultSneatDBProvider(update func(SneatDBProvider) SneatDBProvider) {
+	if update == nil {
+		panic("facade.UpdateDefaultSneatDBProvider: nil update")
+	}
+	defaultSneatDBProviderMu.Lock()
+	defer defaultSneatDBProviderMu.Unlock()
+	provider := update(defaultSneatDBProvider)
+	if provider == nil {
+		panic("facade.UpdateDefaultSneatDBProvider: update returned nil provider")
+	}
+	defaultSneatDBProvider = provider
+}
+
+func uninitializedSneatDBProvider(context.Context) (dal.DB, error) {
+	err := fmt.Errorf("%w: facade.GetSneatDB(context.Context) (dal.DB, error)", ErrNotInitialized)
 	panic(err)
 }

--- a/facade/get_sneat_db_test.go
+++ b/facade/get_sneat_db_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/dal-go/dalgo/adapters/dalgo2memory"
+	"github.com/dal-go/dalgo/dal"
 )
 
 func TestGetDatabase(t *testing.T) {
@@ -16,6 +19,72 @@ func TestGetDatabase(t *testing.T) {
 	//if !errors.Is(err, ErrNotInitialized) {
 	//	t.Error("Expected to return ErrNotInitialized")
 	//}
+}
+
+func TestWithSneatDB_IsolatesContexts(t *testing.T) {
+	t.Parallel()
+	db1 := dalgo2memory.NewDB()
+	db2 := dalgo2memory.NewDB()
+	ctx1 := WithSneatDB(context.Background(), db1)
+	ctx2 := WithSneatDB(context.Background(), db2)
+
+	got1, err := GetSneatDB(ctx1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2, err := GetSneatDB(ctx2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got1 != db1 {
+		t.Error("first context did not resolve its database")
+	}
+	if got2 != db2 {
+		t.Error("second context did not resolve its database")
+	}
+}
+
+func TestWithSneatDBProvider_ReturnsProviderError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("provider failed")
+	ctx := WithSneatDBProvider(context.Background(), func(context.Context) (dal.DB, error) {
+		return nil, wantErr
+	})
+
+	_, err := GetSneatDB(ctx)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("GetSneatDB() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestDefaultSneatDBProviderConfiguration(t *testing.T) {
+	defaultSneatDBProviderMu.RLock()
+	previous := defaultSneatDBProvider
+	defaultSneatDBProviderMu.RUnlock()
+	t.Cleanup(func() { SetDefaultSneatDBProvider(previous) })
+
+	db := dalgo2memory.NewDB()
+	SetDefaultSneatDBProvider(func(context.Context) (dal.DB, error) {
+		return db, nil
+	})
+	decorated := false
+	UpdateDefaultSneatDBProvider(func(provider SneatDBProvider) SneatDBProvider {
+		return func(ctx context.Context) (dal.DB, error) {
+			decorated = true
+			return provider(ctx)
+		}
+	})
+
+	got, err := GetSneatDB(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != db {
+		t.Error("configured default provider did not resolve its database")
+	}
+	if !decorated {
+		t.Error("updated default provider did not invoke its decorator")
+	}
 }
 
 func mustPanicWithErrNotInitialized(t *testing.T) {

--- a/facade/run_transaction_test.go
+++ b/facade/run_transaction_test.go
@@ -25,24 +25,22 @@ func TestRunReadwriteTransaction(t *testing.T) {
 		}
 	})
 
-	mockGetSneatDB := func() {
-		GetSneatDB = func(_ context.Context) (dal.DB, error) {
-			ctrl := gomock.NewController(t)
-			mockDB := mock_dal.NewMockDB(ctrl)
-			mockDB.EXPECT().RunReadwriteTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, f dal.RWTxWorker, options ...dal.TransactionOption) error {
-				err := f(ctx, mock_dal.NewMockReadwriteTransaction(ctrl))
-				if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= 0 {
-					return context.DeadlineExceeded
-				}
-				return err
-			})
-			return mockDB, nil
-		}
+	contextWithMockDB := func(t *testing.T) context.Context {
+		ctrl := gomock.NewController(t)
+		mockDB := mock_dal.NewMockDB(ctrl)
+		mockDB.EXPECT().RunReadwriteTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, f dal.RWTxWorker, options ...dal.TransactionOption) error {
+			err := f(ctx, mock_dal.NewMockReadwriteTransaction(ctrl))
+			if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= 0 {
+				return context.DeadlineExceeded
+			}
+			return err
+		})
+		return WithSneatDB(context.Background(), mockDB)
 	}
 
 	t.Run("no_error", func(t *testing.T) {
-		mockGetSneatDB()
-		ctx := context.Background()
+		t.Parallel()
+		ctx := contextWithMockDB(t)
 		err := RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 			return nil
 		})
@@ -52,8 +50,8 @@ func TestRunReadwriteTransaction(t *testing.T) {
 	})
 
 	t.Run("returns_expected_error", func(t *testing.T) {
-		mockGetSneatDB()
-		ctx := context.Background()
+		t.Parallel()
+		ctx := contextWithMockDB(t)
 		expectedErr := errors.New("expected error")
 		err := RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 			return expectedErr
@@ -64,15 +62,16 @@ func TestRunReadwriteTransaction(t *testing.T) {
 	})
 
 	t.Run("deadline", func(t *testing.T) {
-		mockGetSneatDB()
+		ctx := contextWithMockDB(t)
 		const deadline = time.Millisecond
 		withDefaultDeadLineCalled := 0
+		previousWithDefaultDeadLine := consts4dal.WithDefaultDeadLine
+		t.Cleanup(func() { consts4dal.WithDefaultDeadLine = previousWithDefaultDeadLine })
 		consts4dal.WithDefaultDeadLine = func(ctx context.Context) (context.Context, context.CancelFunc) {
 			withDefaultDeadLineCalled++
 			return context.WithDeadline(ctx, time.Now().Add(deadline))
 		}
 
-		ctx := context.Background()
 		err := RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 			time.Sleep(deadline + time.Millisecond)
 			return nil

--- a/sneatcoretesting/memory_db.go
+++ b/sneatcoretesting/memory_db.go
@@ -20,13 +20,17 @@ func NewMemoryDB() dal.DB {
 	return dalgo2memory.NewDB(dalgo2memory.WithNoReadsAfterWritesInTransaction())
 }
 
-// SetupMemoryDB creates a strict in-memory database and installs it as the
-// facade DB for the lifetime of t. The previous getter is restored at cleanup.
-func SetupMemoryDB(t *testing.T) dal.DB {
-	t.Helper()
+// ContextWithMemoryDB returns a child context with a new strict in-memory
+// database installed as its facade DB.
+func ContextWithMemoryDB(parent context.Context) (context.Context, dal.DB) {
 	db := NewMemoryDB()
-	previous := facade.GetSneatDB
-	facade.GetSneatDB = func(context.Context) (dal.DB, error) { return db, nil }
-	t.Cleanup(func() { facade.GetSneatDB = previous })
-	return db
+	return facade.WithSneatDB(parent, db), db
+}
+
+// SetupMemoryDB creates a strict in-memory database and installs it as the
+// facade DB in a new context. It does not mutate application-wide state, so
+// tests using it can call t.Parallel safely.
+func SetupMemoryDB(t *testing.T) (context.Context, dal.DB) {
+	t.Helper()
+	return ContextWithMemoryDB(context.Background())
 }

--- a/sneatcoretesting/memory_db_test.go
+++ b/sneatcoretesting/memory_db_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 func TestSetupMemoryDB(t *testing.T) {
-	db := sneatcoretesting.SetupMemoryDB(t)
-	got, err := facade.GetSneatDB(context.Background())
+	t.Parallel()
+	ctx, db := sneatcoretesting.SetupMemoryDB(t)
+	got, err := facade.GetSneatDB(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -20,7 +21,24 @@ func TestSetupMemoryDB(t *testing.T) {
 	}
 }
 
+func TestSetupMemoryDB_ParallelIsolation(t *testing.T) {
+	for _, name := range []string{"first", "second"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx, db := sneatcoretesting.SetupMemoryDB(t)
+			got, err := facade.GetSneatDB(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != db {
+				t.Error("parallel test did not resolve its database")
+			}
+		})
+	}
+}
+
 func TestNewMemoryDB_RejectsReadsAfterWrites(t *testing.T) {
+	t.Parallel()
 	db := sneatcoretesting.NewMemoryDB()
 	key := dal.NewKeyWithID("records", "strict-ordering")
 	err := db.RunReadwriteTransaction(context.Background(), func(ctx context.Context, tx dal.ReadwriteTransaction) error {


### PR DESCRIPTION
Makes database overrides context-scoped and migrates tests to isolated memory DB contexts, enabling parallel execution. Adds explicit DB ownership at the selected facade/service boundaries and preserves compatibility wrappers.\n\nValidated with targeted PASS
ok  	github.com/sneat-co/sneat-go-core	1.271s, , and formatting/diff checks.