### PR TITLE
feat(convospec): zero-dependency Typed Action Specification module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,47 @@ on:
 
 jobs:
 
+  # The convospec module is NESTED inside this repo and therefore invisible to
+  # the shared workflow below, which builds the root module only. Without this
+  # job it would ship with no build, vet or test coverage at all — and every
+  # extension contract lib depends on it.
+  convospec_module:
+    name: convospec (nested module)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: convospec
+    env:
+      # This repo may be checked out inside a multi-module workspace; the nested
+      # module must always be verified on its own.
+      GOWORK: "off"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: convospec/go.mod
+      - name: Assert the module stays dependency-free
+        run: |
+          # Extension contract libs are themselves dependency-free and import
+          # this module; a single require here would push a dependency tree into
+          # every one of them. `go list -m all` prints only the module itself
+          # when nothing is required.
+          deps="$(go list -m all | grep -v '^github.com/sneat-co/sneat-go-core/convospec$' || true)"
+          if [ -n "$deps" ]; then
+            echo "convospec must have no dependencies, found:" >&2
+            echo "$deps" >&2
+            exit 1
+          fi
+      - name: Build, vet and test
+        run: |
+          go build ./...
+          go vet ./...
+          go test -race ./...
+      - name: Verify module files are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
   strongo_workflow:
     uses: strongo/cicd/.github/workflows/workflow.yml@main
     permissions:

--- a/convospec/go.mod
+++ b/convospec/go.mod
@@ -1,0 +1,10 @@
+// convospec is intentionally a nested module with NO dependencies — not even
+// on its parent github.com/sneat-co/sneat-go-core. Extension contract libs
+// (ext-<id>/backend) import it to declare conversational capability, and they
+// are themselves dependency-free by design; adding a require here would push a
+// dependency tree into every one of them.
+//
+// Keep this file's require block empty.
+module github.com/sneat-co/sneat-go-core/convospec
+
+go 1.26

--- a/convospec/rule.go
+++ b/convospec/rule.go
@@ -1,0 +1,195 @@
+package convospec
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Rule is one deterministic interpretation: a pattern over the user's message
+// and the action call it produces. Rules let an extension ship a reproducible
+// stand-in for a language model alongside its action declarations, so tests do
+// not depend on a network call or on a model's mood.
+//
+// The TYPE lives here, in the dependency-free specification module, because a
+// contract lib may depend only on convospec — a rule type owned by the mock
+// engine would make an extension's rules unexpressible in the one place they
+// belong. This package owns the data; the engine that matches and ranks rules
+// (convollm/llmmock) lives with the runtime and consumes it.
+type Rule struct {
+	// Pattern matches against the normalized message (see NormalizeText).
+	// Capture groups feed Args via the $n substitution described below.
+	Pattern *regexp.Regexp
+
+	// ActionID is the action this rule resolves to. It MUST be declared in the
+	// same catalog; binding validation rejects a rule naming an unknown action.
+	ActionID string
+
+	// Args maps argument name to a value template. A string value may reference
+	// a capture group as "$1", "$2", … and is substituted before typing. Any
+	// other value is used as-is, which is how a rule supplies a constant (a
+	// default list ID, a standard tracker ID, a canonical unit).
+	//
+	// Values are typed according to the action's ArgDef: a "$1" bound to an int
+	// argument becomes an int, to a float argument a float64, and to a
+	// []string argument a single-element slice. A capture that cannot be typed
+	// makes the rule not match, rather than producing a malformed call.
+	Args map[string]any
+
+	// Priority orders rules when several match the same message; higher wins.
+	// Equal priorities are resolved by declaration order. Use it when a
+	// specific phrasing must beat a general one ("bought milk" as a set-done
+	// rather than as an add).
+	Priority int
+}
+
+// Match applies the rule to already-normalized text. It reports whether the
+// rule matched and, if so, the resolved arguments typed against def.
+//
+// It returns matched=false — rather than an error — when a capture cannot be
+// typed against the action's declaration. A rule that produces a malformed call
+// is a rule that does not apply; failing soft here lets a lower-priority rule
+// or the clarify path take over instead of failing the turn.
+func (r Rule) Match(text string, def ActionDef) (args map[string]any, matched bool) {
+	if r.Pattern == nil {
+		return nil, false
+	}
+	groups := r.Pattern.FindStringSubmatch(text)
+	if groups == nil {
+		return nil, false
+	}
+	args = make(map[string]any, len(r.Args))
+	for name, template := range r.Args {
+		argDef, declared := def.Arg(name)
+		if !declared {
+			return nil, false // rule and declaration disagree
+		}
+		value, ok := resolveTemplate(template, groups, argDef)
+		if !ok {
+			return nil, false
+		}
+		args[name] = value
+	}
+	return args, true
+}
+
+// resolveTemplate substitutes capture groups into a template value and types the
+// result against the argument declaration.
+func resolveTemplate(template any, groups []string, def ArgDef) (any, bool) {
+	text, isString := template.(string)
+	if !isString {
+		return template, true // constants pass through untouched
+	}
+	substituted := substituteGroups(text, groups)
+	switch def.Type {
+	case ArgTypeString:
+		if len(def.Enum) > 0 {
+			for _, allowed := range def.Enum {
+				if substituted == allowed {
+					return substituted, true
+				}
+			}
+			return nil, false
+		}
+		return substituted, true
+	case ArgTypeStringSlice:
+		return []string{substituted}, true
+	case ArgTypeInt:
+		n, err := strconv.Atoi(strings.TrimSpace(substituted))
+		if err != nil {
+			return nil, false
+		}
+		return n, true
+	case ArgTypeFloat:
+		f, err := strconv.ParseFloat(strings.TrimSpace(strings.Replace(substituted, ",", ".", 1)), 64)
+		if err != nil {
+			return nil, false
+		}
+		return f, true
+	case ArgTypeBool:
+		b, err := strconv.ParseBool(strings.TrimSpace(substituted))
+		if err != nil {
+			return nil, false
+		}
+		return b, true
+	default:
+		return nil, false
+	}
+}
+
+// substituteGroups replaces $1..$9 with the corresponding capture group.
+// An out-of-range reference resolves to the empty string, which then fails
+// typing for every non-string argument rather than silently passing zero.
+func substituteGroups(template string, groups []string) string {
+	if !strings.Contains(template, "$") {
+		return template
+	}
+	var b strings.Builder
+	for i := 0; i < len(template); i++ {
+		if template[i] != '$' || i+1 >= len(template) {
+			b.WriteByte(template[i])
+			continue
+		}
+		digit := template[i+1]
+		if digit < '1' || digit > '9' {
+			b.WriteByte(template[i])
+			continue
+		}
+		index := int(digit - '0')
+		if index < len(groups) {
+			b.WriteString(groups[index])
+		}
+		i++ // consume the digit
+	}
+	return b.String()
+}
+
+// ValidateRules reports an error for every rule in the catalog that names an
+// action the catalog does not declare, or that declares no pattern. Catalog
+// binding calls this so a rename applied to an action but not to its rule is
+// caught at construction rather than showing up as a silently unmatched
+// message.
+func (c Catalog) ValidateRules(rules []Rule) error {
+	for i, rule := range rules {
+		if rule.Pattern == nil {
+			return &RuleError{Catalog: c.ID, Index: i, Reason: "rule has no pattern"}
+		}
+		if rule.ActionID == "" {
+			return &RuleError{Catalog: c.ID, Index: i, Reason: "rule has no action ID"}
+		}
+		def, ok := c.Action(rule.ActionID)
+		if !ok {
+			return &RuleError{Catalog: c.ID, Index: i, ActionID: rule.ActionID, Reason: "rule names an action the catalog does not declare"}
+		}
+		for name := range rule.Args {
+			if _, declared := def.Arg(name); !declared {
+				return &RuleError{Catalog: c.ID, Index: i, ActionID: rule.ActionID, Reason: "rule sets argument " + strconv.Quote(name) + " that the action does not declare"}
+			}
+		}
+	}
+	return nil
+}
+
+// RuleError describes a rule that disagrees with the catalog it belongs to.
+type RuleError struct {
+	Catalog  string
+	Index    int
+	ActionID string
+	Reason   string
+}
+
+func (e *RuleError) Error() string {
+	var b strings.Builder
+	b.WriteString("catalog ")
+	b.WriteString(e.Catalog)
+	b.WriteString(": rule ")
+	b.WriteString(strconv.Itoa(e.Index))
+	if e.ActionID != "" {
+		b.WriteString(" (")
+		b.WriteString(e.ActionID)
+		b.WriteString(")")
+	}
+	b.WriteString(": ")
+	b.WriteString(e.Reason)
+	return b.String()
+}

--- a/convospec/rule.go
+++ b/convospec/rule.go
@@ -4,7 +4,32 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
+
+// ActionCall is one typed action invocation: the specification's own notion of
+// "what the interpreter decided to do". It is declared here, rather than only in
+// the runtime's transport model, so that a contract lib can express a
+// deterministic interpretation without importing the runtime.
+type ActionCall struct {
+	ActionID string         `json:"actionID"`
+	Args     map[string]any `json:"args,omitempty"`
+}
+
+// RuleFunc is the escape hatch for interpretations a declarative Rule cannot
+// express: a message that must produce SEVERAL action calls, one that needs
+// relative-date arithmetic against a clock, or one whose target depends on a
+// condition ("bought X" is a set-done, not an add).
+//
+// It returns calls plus matched, and takes the clock explicitly so a test can
+// pin "tomorrow" without touching global state. Its signature deliberately uses
+// only this module's own types and the standard library, so an extension can
+// declare one from its dependency-free contract lib.
+//
+// Prefer a declarative Rule when one suffices — it is inspectable data, and it
+// is validated against the action's ArgDefs. Reach for RuleFunc only for the
+// cases above.
+type RuleFunc func(normalizedText string, now time.Time) (calls []ActionCall, matched bool)
 
 // Rule is one deterministic interpretation: a pattern over the user's message
 // and the action call it produces. Rules let an extension ship a reproducible

--- a/convospec/rule.go
+++ b/convospec/rule.go
@@ -31,6 +31,40 @@ type ActionCall struct {
 // cases above.
 type RuleFunc func(normalizedText string, now time.Time) (calls []ActionCall, matched bool)
 
+// ScopedRuleFunc is a RuleFunc that also sees WHICH actions are on offer for
+// this turn.
+//
+// A few interpretations are legitimately scope-dependent: a bare item name like
+// "milk" should only be read as "add it to the shopping list" when Listus is the
+// only thing listening, and a catch-all fallback must not fire when another
+// extension is also in scope. Without this, such a rule either has to stay in a
+// shared mock package — defeating extension-owned grammars — or silently change
+// behaviour when a host composes one more extension.
+//
+// availableActionIDs holds the action IDs offered this turn, already narrowed by
+// the runtime's prefilter, and always includes the clarify pseudo-action.
+type ScopedRuleFunc func(normalizedText string, now time.Time, availableActionIDs []string) (calls []ActionCall, matched bool)
+
+// OnlyCatalogInScope reports whether every offered action belongs to the given
+// extension prefix (e.g. "lists."), ignoring the clarify pseudo-action.
+//
+// This is the check a scope-dependent rule usually wants: "am I the only one
+// listening?" It is provided here so each extension does not re-implement it,
+// and so the semantics of "exclusive scope" stay identical across extensions.
+func OnlyCatalogInScope(availableActionIDs []string, actionPrefix string) bool {
+	sawOwn := false
+	for _, id := range availableActionIDs {
+		if id == "clarify" {
+			continue
+		}
+		if !strings.HasPrefix(id, actionPrefix) {
+			return false
+		}
+		sawOwn = true
+	}
+	return sawOwn
+}
+
 // Rule is one deterministic interpretation: a pattern over the user's message
 // and the action call it produces. Rules let an extension ship a reproducible
 // stand-in for a language model alongside its action declarations, so tests do

--- a/convospec/rule_test.go
+++ b/convospec/rule_test.go
@@ -1,0 +1,169 @@
+package convospec
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var addEntryDef = ActionDef{
+	ID: "trackers.add_entry", Extension: "trackus",
+	Args: []ArgDef{
+		{Name: "trackerID", Type: ArgTypeString, Required: true},
+		{Name: "value", Type: ArgTypeFloat, Required: true},
+	},
+}
+
+var addItemsDef = ActionDef{
+	ID: "lists.add_items", Extension: "listus",
+	Args: []ArgDef{
+		{Name: "items", Type: ArgTypeStringSlice, Required: true},
+		{Name: "quantity", Type: ArgTypeFloat},
+		{Name: "unit", Type: ArgTypeString, Enum: []string{"L", "kg", "pcs"}},
+		{Name: "listID", Type: ArgTypeString},
+	},
+}
+
+// Both phrasings of a measurement resolve to the same tracker and value.
+func TestRuleMatch_bothWordOrders(t *testing.T) {
+	rules := []Rule{
+		{
+			Pattern:  regexp.MustCompile(`^push-ups (\d+)$`),
+			ActionID: "trackers.add_entry",
+			Args:     map[string]any{"trackerID": "_push_ups", "value": "$1"},
+		},
+		{
+			Pattern:  regexp.MustCompile(`^(\d+) push-ups$`),
+			ActionID: "trackers.add_entry",
+			Args:     map[string]any{"trackerID": "_push_ups", "value": "$1"},
+		},
+	}
+	for i, text := range []string{"push-ups 20", "20 push-ups"} {
+		args, matched := rules[i].Match(NormalizeText(text), addEntryDef)
+		if !matched {
+			t.Fatalf("%q did not match", text)
+		}
+		if args["trackerID"] != "_push_ups" {
+			t.Errorf("%q trackerID = %#v", text, args["trackerID"])
+		}
+		if args["value"] != float64(20) {
+			t.Errorf("%q value = %#v, want float64 20", text, args["value"])
+		}
+	}
+}
+
+// A constant in Args is not a template and must pass through untouched.
+func TestRuleMatch_constantsAndCaptures(t *testing.T) {
+	rule := Rule{
+		Pattern:  regexp.MustCompile(`^(\w+) (\d+) liters$`),
+		ActionID: "lists.add_items",
+		Args: map[string]any{
+			"items":    "$1",
+			"quantity": "$2",
+			"unit":     "L",
+			"listID":   "buy!groceries",
+		},
+	}
+	args, matched := rule.Match(NormalizeText("milk 2 liters"), addItemsDef)
+	if !matched {
+		t.Fatal("expected a match")
+	}
+	items, ok := args["items"].([]string)
+	if !ok || len(items) != 1 || items[0] != "milk" {
+		t.Errorf("items = %#v, want []string{milk}", args["items"])
+	}
+	if args["quantity"] != float64(2) {
+		t.Errorf("quantity = %#v, want float64 2", args["quantity"])
+	}
+	if args["unit"] != "L" || args["listID"] != "buy!groceries" {
+		t.Errorf("constants lost: unit=%#v listID=%#v", args["unit"], args["listID"])
+	}
+}
+
+// A capture that cannot be typed must make the rule not match, so a
+// lower-priority rule or clarify can take over — never a malformed call.
+func TestRuleMatch_untypeableCaptureDoesNotMatch(t *testing.T) {
+	rule := Rule{
+		Pattern:  regexp.MustCompile(`^push-ups (\w+)$`),
+		ActionID: "trackers.add_entry",
+		Args:     map[string]any{"trackerID": "_push_ups", "value": "$1"},
+	}
+	if args, matched := rule.Match(NormalizeText("push-ups many"), addEntryDef); matched {
+		t.Errorf("expected no match for an unparseable value, got %#v", args)
+	}
+}
+
+// A rule may not smuggle a value past the declared enum.
+func TestRuleMatch_enumViolationDoesNotMatch(t *testing.T) {
+	rule := Rule{
+		Pattern:  regexp.MustCompile(`^(\w+) (\d+) (\w+)$`),
+		ActionID: "lists.add_items",
+		Args:     map[string]any{"items": "$1", "quantity": "$2", "unit": "$3"},
+	}
+	if _, matched := rule.Match(NormalizeText("milk 2 liters"), addItemsDef); matched {
+		t.Error(`"liters" is outside the declared unit vocabulary and must not match`)
+	}
+	if _, matched := rule.Match(NormalizeText("flour 2 kg"), addItemsDef); !matched {
+		t.Error(`"kg" is in the declared vocabulary and should match`)
+	}
+}
+
+// A rule referencing an argument the action does not declare is a rule/spec
+// disagreement, not a match.
+func TestRuleMatch_undeclaredArgDoesNotMatch(t *testing.T) {
+	rule := Rule{
+		Pattern:  regexp.MustCompile(`^push-ups (\d+)$`),
+		ActionID: "trackers.add_entry",
+		Args:     map[string]any{"trackerID": "_push_ups", "value": "$1", "nonsense": "x"},
+	}
+	if _, matched := rule.Match(NormalizeText("push-ups 20"), addEntryDef); matched {
+		t.Error("a rule setting an undeclared argument must not match")
+	}
+}
+
+func TestSubstituteGroups_outOfRangeReference(t *testing.T) {
+	rule := Rule{
+		Pattern:  regexp.MustCompile(`^push-ups (\d+)$`),
+		ActionID: "trackers.add_entry",
+		Args:     map[string]any{"trackerID": "$7", "value": "$1"},
+	}
+	args, matched := rule.Match(NormalizeText("push-ups 20"), addEntryDef)
+	if !matched {
+		t.Fatal("expected a match: an out-of-range reference resolves to empty for a string arg")
+	}
+	if args["trackerID"] != "" {
+		t.Errorf("trackerID = %#v, want empty", args["trackerID"])
+	}
+	// The empty value then fails the action's own required-arg validation.
+	if _, err := addEntryDef.ValidateArgs(args); err == nil {
+		t.Error("expected ValidateArgs to reject the empty required trackerID")
+	}
+}
+
+// ValidateRules catches a rename applied to an action but not to its rule.
+func TestValidateRules(t *testing.T) {
+	catalog := Catalog{ID: "trackus", Actions: []ActionDef{addEntryDef}}
+
+	if err := catalog.ValidateRules([]Rule{{
+		Pattern: regexp.MustCompile(`^x$`), ActionID: "trackers.add_entry",
+		Args: map[string]any{"trackerID": "_push_ups"},
+	}}); err != nil {
+		t.Fatalf("valid rule rejected: %v", err)
+	}
+
+	for name, rule := range map[string]Rule{
+		"unknown action": {Pattern: regexp.MustCompile(`^x$`), ActionID: "trackers.renamed"},
+		"no pattern":     {ActionID: "trackers.add_entry"},
+		"no action":      {Pattern: regexp.MustCompile(`^x$`)},
+		"undeclared arg": {Pattern: regexp.MustCompile(`^x$`), ActionID: "trackers.add_entry", Args: map[string]any{"nope": 1}},
+	} {
+		err := catalog.ValidateRules([]Rule{rule})
+		if err == nil {
+			t.Errorf("%s: expected an error", name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "trackus") {
+			t.Errorf("%s: error should name the catalog, got %v", name, err)
+		}
+	}
+}

--- a/convospec/spec.go
+++ b/convospec/spec.go
@@ -1,0 +1,251 @@
+// Package convospec defines the Typed Action Specification — the contract
+// between AI models and Sneat. Definitions are plain data (JSON-serializable)
+// so the same specification drives runtime prompts, CLI inspection, tests,
+// documentation and future MCP/ChatGPT/Claude tool definitions.
+//
+// This package lives in its own dependency-free module so that an extension's
+// contract lib can declare its conversational capability without inheriting an
+// application dependency tree. It therefore imports nothing outside the
+// standard library and knows nothing about DALgo, facades or transports.
+package convospec
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ArgType enumerates supported argument types.
+type ArgType string
+
+const (
+	ArgTypeString      ArgType = "string"
+	ArgTypeInt         ArgType = "int"
+	ArgTypeFloat       ArgType = "float"
+	ArgTypeBool        ArgType = "bool"
+	ArgTypeStringSlice ArgType = "[]string"
+)
+
+// ArgDef describes one argument of an action.
+type ArgDef struct {
+	Name        string   `json:"name"`
+	Type        ArgType  `json:"type"`
+	Required    bool     `json:"required,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty"` // for ArgTypeString: allowed values
+}
+
+// Example maps a user utterance to the action call it should produce.
+// Examples feed LLM prompts, documentation and mock/regression tests.
+type Example struct {
+	UserText string         `json:"userText"`
+	Args     map[string]any `json:"args,omitempty"`
+}
+
+// ActionDef is the specification of one typed action.
+type ActionDef struct {
+	// ID is the action identifier, e.g. "lists.add_items".
+	ID string `json:"id"`
+	// Extension is the owning Sneat extension, e.g. "listus". It is a plain
+	// string rather than coretypes.ExtID so this module stays dependency-free.
+	Extension string `json:"extension"`
+	Summary   string `json:"summary"`
+	// Description is shown to the LLM; write it for the model.
+	Description string   `json:"description,omitempty"`
+	Args        []ArgDef `json:"args,omitempty"`
+	// Confirm marks the action as requiring explicit user confirmation
+	// before execution (destructive or hard-to-reverse operations).
+	Confirm bool `json:"confirm,omitempty"`
+	// Examples of user text mapping to this action.
+	Examples []Example `json:"examples,omitempty"`
+	// Result describes the expected result shape in one line.
+	Result string `json:"result,omitempty"`
+}
+
+// Arg returns the argument definition with the given name, if present.
+func (d ActionDef) Arg(name string) (ArgDef, bool) {
+	for _, a := range d.Args {
+		if a.Name == name {
+			return a, true
+		}
+	}
+	return ArgDef{}, false
+}
+
+// Catalog groups the action definitions contributed by one extension,
+// together with interpretation hints for the LLM.
+type Catalog struct {
+	// ID is the catalog identifier; by convention the extension ID.
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	// PromptHints are scope-specific interpretation rules, e.g. for listus:
+	// "A bare item name like 'milk' means lists.add_items to the groceries list."
+	PromptHints []string `json:"promptHints,omitempty"`
+	// Triggers is the lowercase word/phrase vocabulary this extension is
+	// listening for. It is a ROUTING INPUT ONLY: the runtime may use it to
+	// narrow the action set offered to the model, and it never affects how an
+	// action is validated or executed. An empty Triggers set is legal and
+	// simply means this catalog never narrows the action set.
+	Triggers []string    `json:"triggers,omitempty"`
+	Actions  []ActionDef `json:"actions"`
+}
+
+// Action returns the action definition with the given ID, if present.
+func (c Catalog) Action(id string) (ActionDef, bool) {
+	for _, a := range c.Actions {
+		if a.ID == id {
+			return a, true
+		}
+	}
+	return ActionDef{}, false
+}
+
+// MatchesTriggers reports whether any of the catalog's declared triggers
+// occurs in text. text is expected to be already normalized (lowercase);
+// NormalizeText produces the expected form. A catalog with no triggers never
+// matches, so it can only ever be reached through the unnarrowed action set.
+func (c Catalog) MatchesTriggers(text string) bool {
+	for _, trigger := range c.Triggers {
+		if trigger == "" {
+			continue
+		}
+		if strings.Contains(text, trigger) {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeText lowercases text and collapses the punctuation that separates
+// words in chat messages into single spaces, so a declared trigger like
+// "push-ups" matches "Push-ups: 20" and "20 PUSH-UPS!". Hyphens are preserved
+// because triggers themselves are hyphenated.
+func NormalizeText(text string) string {
+	lowered := strings.ToLower(text)
+	var b strings.Builder
+	b.Grow(len(lowered))
+	for _, r := range lowered {
+		switch r {
+		case ',', '.', ':', ';', '!', '?', '(', ')', '[', ']', '"', '\'', '\n', '\t':
+			b.WriteByte(' ')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+// ValidateArgs checks the given arguments against the definition and returns
+// a normalized copy: JSON numbers are converted for int args, []any of
+// strings for []string args. Unknown argument names are rejected so that
+// model drift is caught early instead of being silently ignored.
+func (d ActionDef) ValidateArgs(args map[string]any) (map[string]any, error) {
+	normalized := make(map[string]any, len(args))
+	defs := make(map[string]ArgDef, len(d.Args))
+	for _, a := range d.Args {
+		defs[a.Name] = a
+	}
+	for name, value := range args {
+		def, ok := defs[name]
+		if !ok {
+			return nil, fmt.Errorf("%w: action %s does not define argument %q", ErrInvalidArgs, d.ID, name)
+		}
+		v, err := normalizeArg(def, value)
+		if err != nil {
+			return nil, fmt.Errorf("%w: action %s argument %q: %v", ErrInvalidArgs, d.ID, name, err)
+		}
+		normalized[name] = v
+	}
+	for _, a := range d.Args {
+		if a.Required {
+			if v, ok := normalized[a.Name]; !ok || isEmptyValue(v) {
+				return nil, fmt.Errorf("%w: action %s is missing required argument %q", ErrInvalidArgs, d.ID, a.Name)
+			}
+		}
+	}
+	return normalized, nil
+}
+
+// ErrInvalidArgs indicates an action call that does not match its definition.
+var ErrInvalidArgs = fmt.Errorf("invalid action arguments")
+
+func normalizeArg(def ArgDef, value any) (any, error) {
+	switch def.Type {
+	case ArgTypeString:
+		s, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string, got %T", value)
+		}
+		if len(def.Enum) > 0 {
+			for _, e := range def.Enum {
+				if s == e {
+					return s, nil
+				}
+			}
+			return nil, fmt.Errorf("value %q is not one of %v", s, def.Enum)
+		}
+		return s, nil
+	case ArgTypeInt:
+		switch n := value.(type) {
+		case int:
+			return n, nil
+		case int64:
+			return int(n), nil
+		case float64: // JSON number
+			if n != float64(int(n)) {
+				return nil, fmt.Errorf("expected integer, got %v", n)
+			}
+			return int(n), nil
+		default:
+			return nil, fmt.Errorf("expected integer, got %T", value)
+		}
+	case ArgTypeFloat:
+		switch n := value.(type) {
+		case float64:
+			return n, nil
+		case float32:
+			return float64(n), nil
+		case int:
+			return float64(n), nil
+		case int64:
+			return float64(n), nil
+		default:
+			return nil, fmt.Errorf("expected number, got %T", value)
+		}
+	case ArgTypeBool:
+		b, ok := value.(bool)
+		if !ok {
+			return nil, fmt.Errorf("expected bool, got %T", value)
+		}
+		return b, nil
+	case ArgTypeStringSlice:
+		switch s := value.(type) {
+		case []string:
+			return s, nil
+		case []any:
+			result := make([]string, 0, len(s))
+			for _, item := range s {
+				str, ok := item.(string)
+				if !ok {
+					return nil, fmt.Errorf("expected string element, got %T", item)
+				}
+				result = append(result, str)
+			}
+			return result, nil
+		default:
+			return nil, fmt.Errorf("expected []string, got %T", value)
+		}
+	default:
+		return nil, fmt.Errorf("unknown argument type %q", def.Type)
+	}
+}
+
+func isEmptyValue(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return t == ""
+	case []string:
+		return len(t) == 0
+	default:
+		return v == nil
+	}
+}

--- a/convospec/spec.go
+++ b/convospec/spec.go
@@ -150,7 +150,15 @@ func NormalizeText(text string) string {
 			} else {
 				b.WriteByte(' ')
 			}
-		case ':', ';', '!', '?', '(', ')', '[', ']', '"', '\'', '\n', '\t':
+		case '\'', '\u2019':
+			// An apostrophe INSIDE a word is elided, not spaced: "what's"
+			// becomes "whats", so a pattern written as `what'?s` still matches.
+			// Turning it into a space split the word in two and silently broke
+			// every such rule.
+			if !isLetter(prevRune(lowered, i)) || !isLetter(nextRune(lowered, i)) {
+				b.WriteByte(' ')
+			}
+		case ':', ';', '!', '?', '(', ')', '[', ']', '"', '\n', '\t':
 			b.WriteByte(' ')
 		default:
 			b.WriteRune(r)
@@ -174,6 +182,8 @@ func nextRune(runes []rune, i int) rune {
 }
 
 func isDigit(r rune) bool { return r >= '0' && r <= '9' }
+
+func isLetter(r rune) bool { return r >= 'a' && r <= 'z' }
 
 // ValidateArgs checks the given arguments against the definition and returns
 // a normalized copy: JSON numbers are converted for int args, []any of

--- a/convospec/spec.go
+++ b/convospec/spec.go
@@ -134,13 +134,23 @@ func (c Catalog) MatchesTriggers(text string) bool {
 // words in chat messages into single spaces, so a declared trigger like
 // "push-ups" matches "Push-ups: 20" and "20 PUSH-UPS!". Hyphens are preserved
 // because triggers themselves are hyphenated.
+//
+// A '.' or ',' BETWEEN DIGITS is preserved, because it is a decimal separator
+// rather than punctuation: stripping it silently turned "80.5" into "80 5" and
+// "2.5 km" into "2 5 km", which then failed to parse as a measurement.
 func NormalizeText(text string) string {
-	lowered := strings.ToLower(text)
+	lowered := []rune(strings.ToLower(text))
 	var b strings.Builder
 	b.Grow(len(lowered))
-	for _, r := range lowered {
+	for i, r := range lowered {
 		switch r {
-		case ',', '.', ':', ';', '!', '?', '(', ')', '[', ']', '"', '\'', '\n', '\t':
+		case '.', ',':
+			if isDigit(prevRune(lowered, i)) && isDigit(nextRune(lowered, i)) {
+				b.WriteRune(r) // decimal separator
+			} else {
+				b.WriteByte(' ')
+			}
+		case ':', ';', '!', '?', '(', ')', '[', ']', '"', '\'', '\n', '\t':
 			b.WriteByte(' ')
 		default:
 			b.WriteRune(r)
@@ -148,6 +158,22 @@ func NormalizeText(text string) string {
 	}
 	return strings.Join(strings.Fields(b.String()), " ")
 }
+
+func prevRune(runes []rune, i int) rune {
+	if i == 0 {
+		return 0
+	}
+	return runes[i-1]
+}
+
+func nextRune(runes []rune, i int) rune {
+	if i+1 >= len(runes) {
+		return 0
+	}
+	return runes[i+1]
+}
+
+func isDigit(r rune) bool { return r >= '0' && r <= '9' }
 
 // ValidateArgs checks the given arguments against the definition and returns
 // a normalized copy: JSON numbers are converted for int args, []any of

--- a/convospec/spec.go
+++ b/convospec/spec.go
@@ -99,16 +99,31 @@ func (c Catalog) Action(id string) (ActionDef, bool) {
 	return ActionDef{}, false
 }
 
-// MatchesTriggers reports whether any of the catalog's declared triggers
-// occurs in text. text is expected to be already normalized (lowercase);
-// NormalizeText produces the expected form. A catalog with no triggers never
-// matches, so it can only ever be reached through the unnarrowed action set.
+// MatchesTriggers reports whether any of the catalog's declared triggers occurs
+// in text as a WHOLE WORD (or whole run of words, for multi-word triggers).
+// text is expected to be already normalized; NormalizeText produces that form.
+//
+// Word-boundary rather than substring matching is deliberate. A routing
+// prefilter that narrows on a single matching catalog can only ever misroute
+// through a false positive, and substring matching manufactures them: a trigger
+// "km" would match "kmart", sending a shopping-list message to a tracker. The
+// cost is that morphological variants must be declared explicitly ("buy" does
+// not match "buying"), which is the right trade — an explicitly listed trigger
+// is reviewable, an accidental substring hit is not.
+//
+// A catalog with no triggers never matches, so it can only be reached through
+// the unnarrowed action set.
 func (c Catalog) MatchesTriggers(text string) bool {
+	if text == "" {
+		return false
+	}
+	padded := " " + text + " "
 	for _, trigger := range c.Triggers {
+		trigger = strings.TrimSpace(strings.ToLower(trigger))
 		if trigger == "" {
 			continue
 		}
-		if strings.Contains(text, trigger) {
+		if strings.Contains(padded, " "+trigger+" ") {
 			return true
 		}
 	}

--- a/convospec/spec_test.go
+++ b/convospec/spec_test.go
@@ -100,6 +100,14 @@ func TestNormalizeText(t *testing.T) {
 		"milk, 2 liters":   "milk 2 liters",
 		"  bought   milk ": "bought milk",
 		"What's on it?":    "what s on it",
+		// A decimal separator is not punctuation: stripping it turned "80.5"
+		// into "80 5" and the measurement stopped parsing.
+		"my weight is 80.5": "my weight is 80.5",
+		"ran 2.5 km":        "ran 2.5 km",
+		"80,5 kg":           "80,5 kg",
+		// A period that is NOT between digits is still punctuation.
+		"bought milk. bought bread": "bought milk bought bread",
+		"2. milk":                   "2 milk",
 	} {
 		if got := NormalizeText(input); got != want {
 			t.Errorf("NormalizeText(%q) = %q, want %q", input, got, want)

--- a/convospec/spec_test.go
+++ b/convospec/spec_test.go
@@ -1,0 +1,140 @@
+package convospec
+
+import (
+	"errors"
+	"testing"
+)
+
+var testDef = ActionDef{
+	ID: "test.action",
+	Args: []ArgDef{
+		{Name: "title", Type: ArgTypeString, Required: true},
+		{Name: "count", Type: ArgTypeInt},
+		{Name: "amount", Type: ArgTypeFloat},
+		{Name: "done", Type: ArgTypeBool},
+		{Name: "items", Type: ArgTypeStringSlice},
+		{Name: "kind", Type: ArgTypeString, Enum: []string{"a", "b"}},
+	},
+}
+
+func TestValidateArgs_normalizesTypes(t *testing.T) {
+	args, err := testDef.ValidateArgs(map[string]any{
+		"title":  "hello",
+		"count":  float64(3), // JSON number
+		"amount": 2,          // int widened to float
+		"done":   true,
+		"items":  []any{"x", "y"},
+		"kind":   "a",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args["count"] != 3 {
+		t.Errorf("count: want int 3, got %#v", args["count"])
+	}
+	if args["amount"] != float64(2) {
+		t.Errorf("amount: want float64 2, got %#v", args["amount"])
+	}
+	items, ok := args["items"].([]string)
+	if !ok || len(items) != 2 || items[0] != "x" {
+		t.Errorf("items: want []string{x,y}, got %#v", args["items"])
+	}
+}
+
+func TestValidateArgs_missingRequired(t *testing.T) {
+	if _, err := testDef.ValidateArgs(map[string]any{}); !errors.Is(err, ErrInvalidArgs) {
+		t.Fatalf("want ErrInvalidArgs, got %v", err)
+	}
+}
+
+func TestValidateArgs_unknownArg(t *testing.T) {
+	if _, err := testDef.ValidateArgs(map[string]any{"title": "x", "nope": 1}); !errors.Is(err, ErrInvalidArgs) {
+		t.Fatalf("want ErrInvalidArgs, got %v", err)
+	}
+}
+
+func TestValidateArgs_enumViolation(t *testing.T) {
+	if _, err := testDef.ValidateArgs(map[string]any{"title": "x", "kind": "z"}); !errors.Is(err, ErrInvalidArgs) {
+		t.Fatalf("want ErrInvalidArgs, got %v", err)
+	}
+}
+
+func TestValidateArgs_wrongTypes(t *testing.T) {
+	for name, args := range map[string]map[string]any{
+		"int as string":     {"title": "x", "count": "3"},
+		"fractional number": {"title": "x", "count": 3.5},
+		"float as string":   {"title": "x", "amount": "2"},
+		"bool as string":    {"title": "x", "done": "yes"},
+		"non-string slice":  {"title": "x", "items": []any{1}},
+		"required empty":    {"title": ""},
+	} {
+		if _, err := testDef.ValidateArgs(args); !errors.Is(err, ErrInvalidArgs) {
+			t.Errorf("%s: want ErrInvalidArgs, got %v", name, err)
+		}
+	}
+}
+
+func TestCatalogAction(t *testing.T) {
+	c := Catalog{ID: "test", Actions: []ActionDef{testDef}}
+	if _, ok := c.Action("test.action"); !ok {
+		t.Error("expected to find test.action")
+	}
+	if _, ok := c.Action("missing"); ok {
+		t.Error("did not expect to find missing action")
+	}
+}
+
+func TestActionDefArg(t *testing.T) {
+	if def, ok := testDef.Arg("count"); !ok || def.Type != ArgTypeInt {
+		t.Errorf("Arg(count) = %+v, %v", def, ok)
+	}
+	if _, ok := testDef.Arg("missing"); ok {
+		t.Error("did not expect to find missing arg")
+	}
+}
+
+func TestNormalizeText(t *testing.T) {
+	for input, want := range map[string]string{
+		"Push-ups: 20":     "push-ups 20",
+		"20 PUSH-UPS!":     "20 push-ups",
+		"milk, 2 liters":   "milk 2 liters",
+		"  bought   milk ": "bought milk",
+		"What's on it?":    "what s on it",
+	} {
+		if got := NormalizeText(input); got != want {
+			t.Errorf("NormalizeText(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestCatalogMatchesTriggers(t *testing.T) {
+	trackus := Catalog{ID: "trackus", Triggers: []string{"push-ups", "pull-ups", "km"}}
+	for _, text := range []string{"push-ups 20", "20 push-ups", "10 pull-ups"} {
+		if !trackus.MatchesTriggers(NormalizeText(text)) {
+			t.Errorf("expected %q to match trackus triggers", text)
+		}
+	}
+	if trackus.MatchesTriggers(NormalizeText("milk 2 liters")) {
+		t.Error("did not expect milk to match trackus triggers")
+	}
+}
+
+// A catalog that declares no triggers must never match, so it is only ever
+// reachable through the unnarrowed action set.
+func TestCatalogWithoutTriggersNeverMatches(t *testing.T) {
+	quiet := Catalog{ID: "quiet"}
+	for _, text := range []string{"anything at all", ""} {
+		if quiet.MatchesTriggers(NormalizeText(text)) {
+			t.Errorf("catalog with no triggers matched %q", text)
+		}
+	}
+}
+
+// An empty-string trigger must not turn into a match-everything rule, which is
+// what strings.Contains would do if it were not skipped.
+func TestEmptyTriggerIsIgnored(t *testing.T) {
+	sloppy := Catalog{ID: "sloppy", Triggers: []string{""}}
+	if sloppy.MatchesTriggers(NormalizeText("milk")) {
+		t.Error("empty trigger must not match")
+	}
+}

--- a/convospec/spec_test.go
+++ b/convospec/spec_test.go
@@ -99,7 +99,9 @@ func TestNormalizeText(t *testing.T) {
 		"20 PUSH-UPS!":     "20 push-ups",
 		"milk, 2 liters":   "milk 2 liters",
 		"  bought   milk ": "bought milk",
-		"What's on it?":    "what s on it",
+		"What's on it?":    "whats on it",
+		"who's going?":     "whos going",
+		"'quoted' words":   "quoted words",
 		// A decimal separator is not punctuation: stripping it turned "80.5"
 		// into "80 5" and the measurement stopped parsing.
 		"my weight is 80.5": "my weight is 80.5",

--- a/convospec/spec_test.go
+++ b/convospec/spec_test.go
@@ -133,8 +133,40 @@ func TestCatalogWithoutTriggersNeverMatches(t *testing.T) {
 // An empty-string trigger must not turn into a match-everything rule, which is
 // what strings.Contains would do if it were not skipped.
 func TestEmptyTriggerIsIgnored(t *testing.T) {
-	sloppy := Catalog{ID: "sloppy", Triggers: []string{""}}
+	sloppy := Catalog{ID: "sloppy", Triggers: []string{"", "   "}}
 	if sloppy.MatchesTriggers(NormalizeText("milk")) {
 		t.Error("empty trigger must not match")
+	}
+}
+
+// Triggers match whole words only. Substring matching would let a short trigger
+// like "km" claim "kmart" and misroute the message, and a single false-positive
+// catalog is the only way a fail-open prefilter can route wrongly.
+func TestTriggersMatchWholeWordsOnly(t *testing.T) {
+	trackus := Catalog{ID: "trackus", Triggers: []string{"km", "kg", "ran"}}
+	for _, text := range []string{"ran 10 km", "weighed 80 kg", "10 KM"} {
+		if !trackus.MatchesTriggers(NormalizeText(text)) {
+			t.Errorf("expected %q to match", text)
+		}
+	}
+	for _, text := range []string{
+		"buy socks at kmart",  // km inside kmart
+		"branding guidelines", // ran inside branding
+		"kgb documentary",     // kg inside kgb
+	} {
+		if trackus.MatchesTriggers(NormalizeText(text)) {
+			t.Errorf("substring match leaked: %q must not match", text)
+		}
+	}
+}
+
+// A multi-word trigger must match as a contiguous run of words.
+func TestMultiWordTrigger(t *testing.T) {
+	listus := Catalog{ID: "listus", Triggers: []string{"shopping list"}}
+	if !listus.MatchesTriggers(NormalizeText("add milk to my shopping list, please")) {
+		t.Error("expected multi-word trigger to match")
+	}
+	if listus.MatchesTriggers(NormalizeText("shopping for a list of books")) {
+		t.Error("multi-word trigger must match contiguous words only")
 	}
 }


### PR DESCRIPTION
Adds `github.com/sneat-co/sneat-go-core/convospec` — a **nested module with an empty require block** — so an extension's contract lib can declare its conversational capability without inheriting an application dependency tree.

The `ext-<id>/backend` contract libs are themselves dependency-free by design. Putting these types in `sneat-go-core` proper would have dragged dalgo, firestore and the rest into every one of them purely to declare an action spec; a nested module keeps that property while avoiding a new repo.

## What's in it

- The specification types (`ActionDef`, `ArgDef`, `Catalog`, `Example`) ported from `sneat-bots/platform/convo/convospec`, with `Extension` reduced to a plain `string` so the module needs no import of its own parent.
- `Catalog.Triggers` plus `MatchesTriggers`/`NormalizeText` — the routing vocabulary an extension declares.
- `Rule` (declarative pattern → action call, validated against the action's `ArgDef`s), `RuleFunc` (multi-call, relative dates, conditional targets) and `ScopedRuleFunc` (interpretations that depend on which actions are on offer).
- `ArgTypeFloat`, needed for Listus item quantity and Trackus measurements.

## Two bugs worth calling out, both caught by tests

- **`NormalizeText` destroyed decimals.** Stripping `.` as punctuation turned `80.5` into `80 5`, so every fractional measurement stopped parsing. A `.`/`,` between digits is now preserved.
- **Trigger matching was substring-based**, so `km` matched `kmart` — sending a shopping message to a tracker. Now word-boundary. This matters because a false positive on exactly one catalog is the *only* way the fail-open routing prefilter can misroute.

Apostrophes are elided rather than spaced (`what's` → `whats`), because spacing split the word and silently broke every pattern written as `what'?s`.

## CI

The shared reusable workflow builds the root module only, so the nested module gets its own job — otherwise it would ship with no coverage at all. That job also asserts the module stays dependency-free, since that property is the entire point.

Spec: [`conversational-extension-capability`](https://github.com/sneat-co/backstage/blob/main/spec/features/conversational-extension-capability/README.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oLc6NHcbs832y44pANFyB