### PR TITLE
fix(convospec): keep a comma as its own token — it is a list delimiter

### DIFF
--- a/convospec/spec.go
+++ b/convospec/spec.go
@@ -144,12 +144,24 @@ func NormalizeText(text string) string {
 	b.Grow(len(lowered))
 	for i, r := range lowered {
 		switch r {
-		case '.', ',':
+		case '.':
 			if isDigit(prevRune(lowered, i)) && isDigit(nextRune(lowered, i)) {
 				b.WriteRune(r) // decimal separator
 			} else {
 				b.WriteByte(' ')
 			}
+		case ',':
+			if isDigit(prevRune(lowered, i)) && isDigit(nextRune(lowered, i)) {
+				b.WriteRune(r) // decimal separator, e.g. "80,5"
+				break
+			}
+			// A comma is kept as its OWN token rather than dropped, because it
+			// is a list delimiter: "buy milk, bread, eggs and apples" is four
+			// items, and replacing the commas with spaces left nothing to split
+			// on but "and" — collapsing three items into one titled
+			// "milk bread eggs". Spacing it keeps word-boundary trigger
+			// matching intact while leaving the delimiter visible to rules.
+			b.WriteString(" , ")
 		case '\'', '\u2019':
 			// An apostrophe INSIDE a word is elided, not spaced: "what's"
 			// becomes "whats", so a pattern written as `what'?s` still matches.

--- a/convospec/spec_test.go
+++ b/convospec/spec_test.go
@@ -95,13 +95,17 @@ func TestActionDefArg(t *testing.T) {
 
 func TestNormalizeText(t *testing.T) {
 	for input, want := range map[string]string{
-		"Push-ups: 20":     "push-ups 20",
-		"20 PUSH-UPS!":     "20 push-ups",
-		"milk, 2 liters":   "milk 2 liters",
-		"  bought   milk ": "bought milk",
-		"What's on it?":    "whats on it",
-		"who's going?":     "whos going",
-		"'quoted' words":   "quoted words",
+		"Push-ups: 20": "push-ups 20",
+		"20 PUSH-UPS!": "20 push-ups",
+		// A comma is a LIST DELIMITER and must survive as its own token:
+		// dropping it left "buy milk, bread, eggs and apples" with nothing to
+		// split on but "and", collapsing three items into one.
+		"milk, 2 liters":                   "milk , 2 liters",
+		"buy milk, bread, eggs and apples": "buy milk , bread , eggs and apples",
+		"  bought   milk ":                 "bought milk",
+		"What's on it?":                    "whats on it",
+		"who's going?":                     "whos going",
+		"'quoted' words":                   "quoted words",
 		// A decimal separator is not punctuation: stripping it turned "80.5"
 		// into "80 5" and the measurement stopped parsing.
 		"my weight is 80.5": "my weight is 80.5",


### PR DESCRIPTION
`NormalizeText` replaced a comma with a space, destroying the delimiter that multi-item splitting depends on.

`buy milk, bread, eggs and apples` normalised to `buy milk bread eggs and apples`, leaving nothing to split on but `and` — so it produced **2** list items (`milk bread eggs`, `apples`) where **4** were expected.

A comma is now emitted as its own spaced token. Word-boundary trigger matching is unaffected, since it compares whole space-separated tokens either way, and a comma **between digits** is still preserved as a decimal separator (`80,5`).

Caught by `sneat-go`'s host smoke test driving the real Telegram webhook — two repos downstream of this one, and only *after* the `sneat-bots` suite had gone green. Worth noting as a gap: no test at this level or in `sneat-bots` covered a comma-separated item list end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oLc6NHcbs832y44pANFyB