### PR TITLE
fix(convospec): a period is a separator only when it ends a token

### DIFF
--- a/convospec/spec.go
+++ b/convospec/spec.go
@@ -145,8 +145,14 @@ func NormalizeText(text string) string {
 	for i, r := range lowered {
 		switch r {
 		case '.':
-			if isDigit(prevRune(lowered, i)) && isDigit(nextRune(lowered, i)) {
-				b.WriteRune(r) // decimal separator
+			// A '.' is a separator only when it ENDS a token. Between two
+			// alphanumerics it is part of the token and must survive:
+			// "80.5" is a decimal, "jane@example.com" is an address, and
+			// dropping it there made an email impossible to extract at all —
+			// the rule never saw a dot to match. "bought milk. bought bread"
+			// still splits, because that '.' is followed by a space.
+			if isAlnum(prevRune(lowered, i)) && isAlnum(nextRune(lowered, i)) {
+				b.WriteRune(r)
 			} else {
 				b.WriteByte(' ')
 			}
@@ -196,6 +202,8 @@ func nextRune(runes []rune, i int) rune {
 func isDigit(r rune) bool { return r >= '0' && r <= '9' }
 
 func isLetter(r rune) bool { return r >= 'a' && r <= 'z' }
+
+func isAlnum(r rune) bool { return isDigit(r) || isLetter(r) }
 
 // ValidateArgs checks the given arguments against the definition and returns
 // a normalized copy: JSON numbers are converted for int args, []any of

--- a/convospec/spec_test.go
+++ b/convospec/spec_test.go
@@ -111,9 +111,13 @@ func TestNormalizeText(t *testing.T) {
 		"my weight is 80.5": "my weight is 80.5",
 		"ran 2.5 km":        "ran 2.5 km",
 		"80,5 kg":           "80,5 kg",
-		// A period that is NOT between digits is still punctuation.
+		// A period that ENDS a token is still punctuation.
 		"bought milk. bought bread": "bought milk bought bread",
 		"2. milk":                   "2 milk",
+		// ...but between alphanumerics it is part of the token. Dropping it
+		// here made an email impossible to extract: the rule never saw a dot.
+		"add jane jane@example.com to contacts": "add jane jane@example.com to contacts",
+		"visit sneat.app today":                 "visit sneat.app today",
 	} {
 		if got := NormalizeText(input); got != want {
 			t.Errorf("NormalizeText(%q) = %q, want %q", input, got, want)


### PR DESCRIPTION
`NormalizeText` dropped every `.` that was not between two **digits**, so `jane@example.com` became `jane@example com`.

Consequence: Contactus's email-extraction rule **could never fire in production** — it never saw a dot to match. The rule looked correct and its unit test passed, because that test exercised the regex directly rather than through normalization.

The digit-only carve-out was simply too narrow. A `.` between two alphanumerics is part of the token — a decimal (`80.5`), an address (`jane@example.com`), a domain (`sneat.app`) — and only a `.` that **ends** a token is punctuation. `bought milk. bought bread` still splits, because that period is followed by a space.

One of three latent bugs found while writing tests for the conversational pilots and now being fixed rather than left documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oLc6NHcbs832y44pANFyB