### PR TITLE
feat(coretypes): type group space contracts

### DIFF
--- a/coretypes/space_type.go
+++ b/coretypes/space_type.go
@@ -17,7 +17,9 @@ const (
 	// SpaceTypeFamily is a "family" space type
 	SpaceTypeFamily SpaceType = "family"
 
-	SpaceTypeGroup = "group"
+	// SpaceTypeGroup is a member-managed group space, such as a Circleus
+	// circle. Group spaces are always referenced with a full SpaceRef.
+	SpaceTypeGroup SpaceType = "group"
 
 	// SpaceTypeCompany is a "company" space type
 	SpaceTypeCompany SpaceType = "company"

--- a/coretypes/space_type.go
+++ b/coretypes/space_type.go
@@ -18,7 +18,8 @@ const (
 	SpaceTypeFamily SpaceType = "family"
 
 	// SpaceTypeGroup is a member-managed group space, such as a Circleus
-	// circle. Group spaces are always referenced with a full SpaceRef.
+	// circle. NewSpaceRef constructs its full references; NewWeakSpaceRef
+	// deliberately rejects this type because a group reference needs an ID.
 	SpaceTypeGroup SpaceType = "group"
 
 	// SpaceTypeCompany is a "company" space type

--- a/coretypes/space_type_test.go
+++ b/coretypes/space_type_test.go
@@ -15,6 +15,7 @@ func TestIsValidSpaceType(t *testing.T) {
 		want bool
 	}{
 		{"SpaceTypePersonal", args{SpaceTypePersonal}, true},
+		{"SpaceTypeGroup", args{SpaceTypeGroup}, true},
 		{"private-now-invalid", args{"private"}, false},
 		{"SpaceTypeSystem", args{SpaceTypeSystem}, true},
 		{"SpaceTypeSpot", args{SpaceTypeSpot}, true},
@@ -27,6 +28,23 @@ func TestIsValidSpaceType(t *testing.T) {
 				t.Errorf("IsValidSpaceType() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSpaceTypeGroupFullRefRoundTrip(t *testing.T) {
+	spaceRef := NewSpaceRef(SpaceTypeGroup, "circle-1")
+
+	if got, want := spaceRef, SpaceRef("group!circle-1"); got != want {
+		t.Errorf("NewSpaceRef() = %q, want %q", got, want)
+	}
+	if got, want := spaceRef.SpaceType(), SpaceTypeGroup; got != want {
+		t.Errorf("SpaceType() = %q, want %q", got, want)
+	}
+	if got, want := spaceRef.SpaceID(), SpaceID("circle-1"); got != want {
+		t.Errorf("SpaceID() = %q, want %q", got, want)
+	}
+	if got, want := spaceRef.UrlPath(), "group/circle-1"; got != want {
+		t.Errorf("UrlPath() = %q, want %q", got, want)
 	}
 }
 

--- a/coretypes/space_type_test.go
+++ b/coretypes/space_type_test.go
@@ -178,6 +178,11 @@ func TestNewWeakSpaceRef(t *testing.T) {
 			args:        args{""},
 			expectPanic: []string{"family", "personal"},
 		},
+		{
+			name:        "group_requires_full_reference",
+			args:        args{SpaceTypeGroup},
+			expectPanic: []string{"family", "personal"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Circleus Task 1 foundation.

Makes the existing group wire value explicitly typed, proves full group SpaceRefs round-trip, and pins that weak group refs remain rejected. No host or domain implementation changes.

Verified by full tests, repeated race tests, vet/build, diff checks, a temporary cross-module workspace, and fresh independent review.