### PR TITLE
feat(coretypes): promote ItemRef and space key builders from sneat-core-modules

### DIFF
--- a/coretypes/item_ref.go
+++ b/coretypes/item_ref.go
@@ -1,0 +1,151 @@
+package coretypes
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/sneat-co/sneat-go-core/validate"
+	"github.com/strongo/validation"
+)
+
+// SpaceItemIDSeparator is the reserved separator used to append an optional
+// "@{spaceID}" suffix to an ItemRef's ItemID (sneat-specs Decision 0002):
+// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
+const SpaceItemIDSeparator = "@"
+
+// ItemRef is a persistence-neutral reference to an item owned by an
+// extension's collection, e.g. a Contactus contact or a Calendarius
+// happening. It was promoted from
+// sneat-core-modules/linkage/dbo4linkage to sneat-go-core/coretypes to break
+// a module import cycle between sneat-core-modules and ext-contactus/backend;
+// sneat-core-modules keeps its own ItemRef as a type alias to this one.
+type ItemRef struct {
+	ExtID      ExtID  `json:"module" firestore:"module"` // TODO: change to `json:"extID" firestore:"extID"`?
+	Collection string `json:"collection" firestore:"collection"`
+	ItemID     string `json:"itemID" firestore:"itemID"`
+	//SpaceID    SpaceID  `json:"spaceID,omitempty" firestore:"spaceID,omitempty"`
+}
+
+// NewItemRefSameSpace returns an ItemRef for an item that lives in the same
+// space as the caller, so itemID must not carry a "@{spaceID}" suffix.
+func NewItemRefSameSpace(extID ExtID, collection, itemID string) ItemRef {
+	if strings.Contains(itemID, SpaceItemIDSeparator) {
+		panic("itemID must not contain a spaceID separated by '@'")
+	}
+	return newItemRef(extID, collection, itemID)
+}
+
+func newItemRef(extID ExtID, collection, itemID string) ItemRef {
+	if extID == "" {
+		panic("extID is required")
+	}
+	if collection == "" {
+		panic("collection is required")
+	}
+	if itemID == "" {
+		panic("itemID is required")
+	}
+	return ItemRef{
+		//SpaceID:    spaceID,
+		ExtID:      extID,
+		Collection: collection,
+		ItemID:     itemID,
+	}
+}
+
+// NewFullItemRef returns an ItemRef in an arbitrary space.
+//
+// specscore: decisions/0002-reserved-extension-space-ids
+// Ref serialization: omit the "@{spaceID}" suffix for the spaceless system
+// namespace. See sneat-specs Decision 0002:
+// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
+func NewFullItemRef(extID ExtID, collection string, spaceID SpaceID, itemID string) ItemRef {
+	if itemID == "" {
+		panic("itemID is required for a full item reference")
+	}
+	if spaceID == "" {
+		// Spaceless system namespace: no "@{spaceID}" suffix is appended.
+		// The record resolves under /ext/{ext-id}/{collection}/{item-id}.
+		return newItemRef(extID, collection, itemID)
+	}
+	return newItemRef(extID, collection, itemID+SpaceItemIDSeparator+string(spaceID))
+}
+
+// NewItemRefFromQueryString builds an ItemRef from URL query parameters:
+// "m" (extension/module ID), "c" (collection), "i" (item ID), and an optional
+// "s" (space ID) that gets appended to the item ID as a "@{spaceID}" suffix.
+func NewItemRefFromQueryString(values url.Values) (itemRef ItemRef, err error) {
+	if itemRef.ExtID = ExtID(values.Get("m")); strings.TrimSpace(string(itemRef.ExtID)) == "" {
+		return itemRef, errors.New("extension ID 'm' parameter is required")
+	}
+	if itemRef.Collection = values.Get("c"); strings.TrimSpace(itemRef.Collection) == "" {
+		return itemRef, errors.New("collectionID 'c' parameter is required")
+	}
+	if itemRef.ItemID = values.Get("i"); strings.TrimSpace(itemRef.ItemID) == "" {
+		return itemRef, errors.New("itemID 'i' parameter is required")
+	}
+	if spaceID := values.Get("s"); spaceID != "" {
+		itemRef.ItemID = itemRef.ItemID + SpaceItemIDSeparator + spaceID
+	}
+	return
+}
+
+// ID returns a stable, order-sensitive string identifier for the item
+// reference. The order is important for the RelatedIDs field.
+func (v ItemRef) ID() string {
+	return fmt.Sprintf("m=%s&c=%s&i=%s", v.ExtID, v.Collection, v.ItemID)
+}
+
+// String implements fmt.Stringer.
+func (v ItemRef) String() string {
+	return fmt.Sprintf("{ExtID=%s,Collection=%s,ItemID=%s}", v.ExtID, v.Collection, v.ItemID)
+}
+
+// DocID returns the bare document id with any optional "@{spaceID}" suffix
+// removed. For a bare itemID it returns the itemID unchanged.
+func (v ItemRef) DocID() string {
+	if i := strings.Index(v.ItemID, SpaceItemIDSeparator); i >= 0 {
+		return v.ItemID[:i]
+	}
+	return v.ItemID
+}
+
+// Validate checks that the item reference has all required fields and that
+// any optional "@{spaceID}" suffix on ItemID is well-formed.
+func (v ItemRef) Validate() error {
+	// SpaceID can be empty for global collections like Happening
+	if v.ExtID == "" {
+		return validation.NewErrRecordIsMissingRequiredField("moduleID")
+	}
+	if v.Collection == "" {
+		return validation.NewErrRecordIsMissingRequiredField("collection")
+	}
+	if v.ItemID == "" {
+		return validation.NewErrRecordIsMissingRequiredField("itemID")
+	}
+	// The ItemID may carry at most one optional "@{spaceID}" suffix (sneat-specs
+	// Decision 0002). "@" is the reserved space separator, so a document id must
+	// never contain it: split on the first "@" and require both the document id
+	// and the spaceID segment to be non-empty, and the spaceID to hold no further
+	// "@". A bare itemID (no "@") is the common case.
+	docID := v.ItemID
+	if i := strings.Index(v.ItemID, SpaceItemIDSeparator); i >= 0 {
+		docID = v.ItemID[:i]
+		spaceID := v.ItemID[i+1:]
+		if docID == "" {
+			return validation.NewErrBadRecordFieldValue("itemID", "empty document id before '@' separator")
+		}
+		if spaceID == "" {
+			return validation.NewErrBadRecordFieldValue("itemID", "empty spaceID after '@' separator")
+		}
+		if strings.Contains(spaceID, SpaceItemIDSeparator) {
+			return validation.NewErrBadRecordFieldValue("itemID", "must not contain more than one '@' separator")
+		}
+	}
+	if err := validate.RecordID(docID); err != nil {
+		return validation.NewErrBadRecordFieldValue("itemID", err.Error())
+	}
+	return nil
+}

--- a/coretypes/item_ref_test.go
+++ b/coretypes/item_ref_test.go
@@ -1,0 +1,235 @@
+package coretypes
+
+import (
+	"net/url"
+	"testing"
+)
+
+// TestItemRef_Validate covers the "@" reserved-separator rules from sneat-specs
+// Decision 0002: a bare itemID and a well-formed "itemID@{spaceID}" composite
+// are valid; a trailing "@" (empty space), a leading "@" (empty doc id), and
+// more than one "@" (an embedded separator in the document id) are rejected.
+func TestItemRef_Validate(t *testing.T) {
+	newRef := func(itemID string) ItemRef {
+		return ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: itemID}
+	}
+	tests := []struct {
+		name    string
+		ref     ItemRef
+		wantErr bool
+	}{
+		{name: "bare", ref: newRef("item1"), wantErr: false},
+		{name: "space_bound_composite", ref: newRef("item1@space1"), wantErr: false},
+		{name: "trailing_at_empty_space", ref: newRef("item1@"), wantErr: true},
+		{name: "leading_at_empty_doc", ref: newRef("@space1"), wantErr: true},
+		{name: "double_at", ref: newRef("item1@space1@x"), wantErr: true},
+		{name: "missing_item_id", ref: newRef(""), wantErr: true},
+		{name: "missing_ext_id", ref: ItemRef{Collection: "contacts", ItemID: "item1"}, wantErr: true},
+		{name: "missing_collection", ref: ItemRef{ExtID: "contactus", ItemID: "item1"}, wantErr: true},
+		{name: "doc_id_contains_whitespace", ref: newRef("item 1"), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.ref.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("ItemRef.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestItemRef_DocID verifies stripping of the optional "@{spaceID}" suffix.
+func TestItemRef_DocID(t *testing.T) {
+	tests := []struct {
+		itemID string
+		want   string
+	}{
+		{itemID: "item1", want: "item1"},
+		{itemID: "item1@space1", want: "item1"},
+		{itemID: "item1@", want: "item1"},
+	}
+	for _, tt := range tests {
+		ref := ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: tt.itemID}
+		if got := ref.DocID(); got != tt.want {
+			t.Errorf("ItemRef.DocID() for %q = %q, want %q", tt.itemID, got, tt.want)
+		}
+	}
+}
+
+func TestItemRef_ID(t *testing.T) {
+	ref := ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: "item1"}
+	want := "m=contactus&c=contacts&i=item1"
+	if got := ref.ID(); got != want {
+		t.Errorf("ItemRef.ID() = %q, want %q", got, want)
+	}
+}
+
+func TestItemRef_String(t *testing.T) {
+	ref := ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: "item1"}
+	want := "{ExtID=contactus,Collection=contacts,ItemID=item1}"
+	if got := ref.String(); got != want {
+		t.Errorf("ItemRef.String() = %q, want %q", got, want)
+	}
+}
+
+// TestNewFullItemRef ports dbo4linkage's TestNewContactFullRef: a spaceID
+// appends the "@{spaceID}" suffix, an empty spaceID resolves to the spaceless
+// system namespace (sneat-specs Decision 0002), and an empty itemID panics.
+func TestNewFullItemRef(t *testing.T) {
+	type args struct {
+		spaceID SpaceID
+		itemID  string
+	}
+	tests := []struct {
+		name string
+		args args
+		want ItemRef
+	}{
+		{
+			name: "normal",
+			args: args{
+				spaceID: "test-space-id",
+				itemID:  "test-contact-id",
+			},
+			want: ItemRef{
+				ExtID:      "contactus",
+				Collection: "contacts",
+				ItemID:     "test-contact-id@test-space-id",
+			},
+		},
+		{
+			// sneat-specs Decision 0002: an empty spaceID denotes the spaceless
+			// system namespace, so no "@{spaceID}" suffix is appended (no panic).
+			name: "empty space resolves to system namespace",
+			args: args{
+				spaceID: "",
+				itemID:  "test-contact-id",
+			},
+			want: ItemRef{
+				ExtID:      "contactus",
+				Collection: "contacts",
+				ItemID:     "test-contact-id",
+			},
+		},
+		{
+			name: "panic on empty itemID",
+			args: args{
+				spaceID: "test-space-id",
+				itemID:  "",
+			},
+			want: ItemRef{
+				ExtID:      "contactus",
+				Collection: "contacts",
+				ItemID:     "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.itemID == "" {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("NewFullItemRef() did not panic on empty itemID")
+					}
+				}()
+			}
+			if got := NewFullItemRef("contactus", "contacts", tt.args.spaceID, tt.args.itemID); got != tt.want {
+				t.Errorf("NewFullItemRef() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewItemRefSameSpace(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		got := NewItemRefSameSpace("contactus", "contacts", "item1")
+		want := ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: "item1"}
+		if got != want {
+			t.Errorf("NewItemRefSameSpace() = %v, want %v", got, want)
+		}
+	})
+	t.Run("panics_on_space_suffix", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected panic on itemID containing '@'")
+			}
+		}()
+		NewItemRefSameSpace("contactus", "contacts", "item1@space1")
+	})
+	t.Run("panics_on_empty_ext_id", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected panic on empty extID")
+			}
+		}()
+		NewItemRefSameSpace("", "contacts", "item1")
+	})
+	t.Run("panics_on_empty_collection", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected panic on empty collection")
+			}
+		}()
+		NewItemRefSameSpace("contactus", "", "item1")
+	})
+	t.Run("panics_on_empty_item_id", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected panic on empty itemID")
+			}
+		}()
+		NewItemRefSameSpace("contactus", "contacts", "")
+	})
+}
+
+// TestNewItemRefFromQueryString_BothShapes verifies that the presence of the
+// "s" (space) query parameter is the sole discriminator (sneat-specs Decision
+// 0002): when present, the itemID carries an "@{spaceID}" suffix (space-bound);
+// when absent, the itemID stays bare (spaceless system namespace). Ported from
+// dbo4linkage's with_related_and_ids_test.go.
+func TestNewItemRefFromQueryString_BothShapes(t *testing.T) {
+	tests := []struct {
+		name       string
+		values     url.Values
+		wantItemID string
+	}{
+		{
+			name:       "space_bound",
+			values:     url.Values{"m": {"contactus"}, "c": {"contacts"}, "i": {"item1"}, "s": {"space1"}},
+			wantItemID: "item1@space1",
+		},
+		{
+			name:       "system_namespace_no_space",
+			values:     url.Values{"m": {"contactus"}, "c": {"contacts"}, "i": {"item1"}},
+			wantItemID: "item1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, err := NewItemRefFromQueryString(tt.values)
+			if err != nil {
+				t.Fatalf("NewItemRefFromQueryString() error = %v", err)
+			}
+			if ref.ItemID != tt.wantItemID {
+				t.Errorf("NewItemRefFromQueryString() ItemID = %q, want %q", ref.ItemID, tt.wantItemID)
+			}
+		})
+	}
+}
+
+func TestNewItemRefFromQueryString_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		values url.Values
+	}{
+		{name: "missing_module", values: url.Values{"c": {"contacts"}, "i": {"item1"}}},
+		{name: "missing_collection", values: url.Values{"m": {"contactus"}, "i": {"item1"}}},
+		{name: "missing_item_id", values: url.Values{"m": {"contactus"}, "c": {"contacts"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewItemRefFromQueryString(tt.values); err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}

--- a/coretypes/space_key.go
+++ b/coretypes/space_key.go
@@ -1,0 +1,74 @@
+package coretypes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dal-go/record"
+	core "github.com/sneat-co/sneat-go-core"
+)
+
+// spacesCollection is the storage collection name for Space records.
+const spacesCollection = "spaces"
+
+// spaceModulesCollection is the storage collection name for a space's
+// (or, when spaceID is empty, the spaceless system namespace's) extension
+// records. The value matches
+// sneat-core-modules/core/coremodels.ExtCollection ("ext"); it is kept as a
+// local literal rather than imported to avoid re-creating the
+// sneat-core-modules <-> sneat-go-core module import cycle this promotion
+// exists to break.
+const spaceModulesCollection = "ext"
+
+const maxSpaceIDLength = 30
+
+// ValidateSpaceID applies the canonical constraints used by Space keys without
+// panicking. Request DTOs must call this before passing untrusted IDs to
+// NewSpaceKey.
+func ValidateSpaceID(spaceID SpaceID) error {
+	if spaceID == "" {
+		return fmt.Errorf("spaceID is empty")
+	}
+	if length := len(spaceID); length > maxSpaceIDLength {
+		return fmt.Errorf("spaceID is %d characters long, maximum is %d", length, maxSpaceIDLength)
+	}
+	if core.IsAlphanumericOrUnderscore(string(spaceID)) {
+		return nil
+	}
+	// Reserved entity-scoped space IDs carry a '~' separator by design:
+	// SpotSpaceID builds "spot~{spotID}" (SpaceTypeSpot venue spaces). Accept
+	// the documented prefix with an alphanumeric suffix; everything else stays
+	// rejected.
+	suffix, ok := strings.CutPrefix(string(spaceID), SpotSpaceIDPrefix)
+	if !ok || suffix == "" || !core.IsAlphanumericOrUnderscore(suffix) {
+		return fmt.Errorf("spaceID contains unsupported characters or uppercase letters: %q", spaceID)
+	}
+	return nil
+}
+
+// NewSpaceKey create new doc ref
+func NewSpaceKey(spaceID SpaceID) *record.Key {
+	if err := ValidateSpaceID(spaceID); err != nil {
+		panic(err.Error())
+	}
+	return record.NewKeyWithID(spacesCollection, string(spaceID))
+}
+
+// NewSpaceModuleKey builds the storage key for an extension's per-space
+// record.
+//
+// specscore: decisions/0002-reserved-extension-space-ids
+// Spaceless key-builder: when the space is empty, build /ext/{ext-id}/... and
+// do NOT call NewSpaceKey (which panics on empty). See sneat-specs Decision
+// 0002:
+// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
+func NewSpaceModuleKey(spaceID SpaceID, moduleID ExtID) *record.Key {
+	if spaceID == "" {
+		// Spaceless system namespace: global/system extension records live at
+		// /ext/{ext-id}/... with no /spaces/{space-id} prefix (sneat-specs
+		// Decision 0002). NewSpaceKey is intentionally NOT called here.
+		return record.NewKeyWithID(spaceModulesCollection, moduleID)
+	}
+	spaceKey := NewSpaceKey(spaceID)
+	return record.NewKeyWithParentAndID(spaceKey, spaceModulesCollection, moduleID)
+}

--- a/coretypes/space_key_test.go
+++ b/coretypes/space_key_test.go
@@ -1,0 +1,102 @@
+package coretypes
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/record"
+)
+
+func TestNewSpaceKey(t *testing.T) {
+	type args struct {
+		id SpaceID
+	}
+	t.Run("should_panic_on_empty_id", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("no expected panic")
+			}
+		}()
+		NewSpaceKey("")
+	})
+	t.Run("should_panic_on_long_id", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("no expected panic")
+			}
+		}()
+		NewSpaceKey("0123456789012345678901234567891")
+	})
+	t.Run("should_panic_on_bare_spot_prefix", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("no expected panic")
+			}
+		}()
+		NewSpaceKey(SpaceID(SpotSpaceIDPrefix))
+	})
+	t.Run("should_panic_on_unknown_tilde_prefix", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("no expected panic")
+			}
+		}()
+		NewSpaceKey("foo~bar")
+	})
+	tests := []struct {
+		name string
+		args args
+		want *record.Key
+	}{
+		{
+			name: "should_pass",
+			args: args{id: "TestSpace"},
+			want: record.NewKeyWithID(spacesCollection, "TestSpace"),
+		},
+		{
+			name: "should_pass_spot_space_id",
+			args: args{id: SpotSpaceID("abc123")},
+			want: record.NewKeyWithID(spacesCollection, "spot~abc123"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewSpaceKey(tt.args.id); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewSpaceKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateSpaceID(t *testing.T) {
+	for _, spaceID := range []SpaceID{"TestSpace", "family_1", SpotSpaceID("abc123")} {
+		if err := ValidateSpaceID(spaceID); err != nil {
+			t.Errorf("ValidateSpaceID(%q) = %v", spaceID, err)
+		}
+	}
+	for _, spaceID := range []SpaceID{
+		"",
+		"family space",
+		" family",
+		"family@space",
+		"0123456789012345678901234567891",
+		SpaceID(SpotSpaceIDPrefix),
+		"foo~bar",
+	} {
+		if err := ValidateSpaceID(spaceID); err == nil {
+			t.Errorf("ValidateSpaceID(%q) = nil, want error", spaceID)
+		}
+	}
+}
+
+// TestNewSpaceModuleKey verifies the space-bound and spaceless module keys.
+// Ported from sneat-core-modules/spaceus/dbo4spaceus's
+// space_module_item_test.go.
+func TestNewSpaceModuleKey(t *testing.T) {
+	if got := NewSpaceModuleKey("space1", "contactus").String(); got != "spaces/space1/ext/contactus" {
+		t.Errorf("NewSpaceModuleKey(space1) = %q", got)
+	}
+	if got := NewSpaceModuleKey("", "contactus").String(); got != "ext/contactus" {
+		t.Errorf("NewSpaceModuleKey(empty) = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Step 1 of 3 in a founder-approved plan to break a real module import cycle
between `sneat-core-modules` and `ext-contactus/backend` (confirmed via
`wb deps graph`), which aborts `wb deps bump --fleet` during graph discovery
for the entire fleet.

- **Forward edge stays**: `sneat-core-modules → ext-contactus/backend` (30
  references to `briefs4contactus`/`const4contactus`) is the documented
  completed shape per `sneat-specs/standards/extension-backend-architecture.md`
  and 20+ repos consume it.
- **Reverse edge is what this unblocks**: `ext-contactus/backend` imports
  `sneat-core-modules` from exactly two non-test files, for two things —
  `dbo4spaceus.NewSpaceModuleKey` and `dbo4linkage.ItemRef` /
  `NewFullItemRef` / `NewItemRefSameSpace`.

This PR promotes both into `sneat-go-core/coretypes`, the kernel both repos
already depend on directly:

- `coretypes/item_ref.go` (+ `item_ref_test.go`): `ItemRef` struct,
  `NewFullItemRef`, `NewItemRefSameSpace`, `NewItemRefFromQueryString`, and
  the `ID`/`String`/`Validate`/`DocID` methods. Source carried a
  `// TODO: Move to sneat-go-core or document why not` on the type — this
  lands that recorded intent.
- `coretypes/space_key.go` (+ `space_key_test.go`): `NewSpaceModuleKey`,
  `NewSpaceKey`, `ValidateSpaceID`.

API is byte-identical to the source (same fields/tags/signatures) so
step 2 (`sneat-core-modules`) can be a pure `type ItemRef =
coretypes.ItemRef` plus forwarding constructor functions for its 16+
internal callers — untouched by this PR. Step 3 (`ext-contactus/backend`)
then repoints its two files at `coretypes` and drops `sneat-core-modules`
from `go.mod` entirely, cutting the cycle. Neither `sneat-core-modules` nor
`ext-contactus` is touched here.

## Domain-free judgement

Read `spec/standards/extension-backend-architecture.md`: kernel fan-in is
~100+ packages, so domain types are barred — but "domain-free primitives"
are explicitly routed to `sneat-go-core` (`coretypes`, `facade`, validation
glue). `ItemRef` is `{ExtID, Collection, ItemID}` with firestore tags — the
exact same primitive family already living in `coretypes`:
`ModuleCollectionRef` is `{ModuleID ExtID, Collection string}` with firestore
tags, and `ItemRef` is structurally that plus one field (`ItemID`). Neither
carries any business vocabulary (no contact name, no happening fields, etc.)
— they're generic addressing primitives used the same way by every
extension, not Contactus-specific. Verdict: domain-free, belongs beside
`EntityRef`/`ModuleCollectionRef`.

## Dependency verification (done before moving anything)

- `ItemRef` + constructors: only `coretypes`, `sneat-go-core/validate`,
  `strongo/validation`, stdlib.
- `NewSpaceModuleKey` → `NewSpaceKey` → `ValidateSpaceID`: only
  `dal-go/record`, `coretypes`, and `sneat-go-core`'s root
  `IsAlphanumericOrUnderscore`. `coremodels.ExtCollection`'s value (`"ext"`)
  is kept as a local literal constant rather than imported, specifically to
  avoid recreating the exact cycle this PR exists to break.
- Confirmed no cycle risk: `go list -deps ./coretypes/...` has zero hits for
  `sneat-core-modules` or `ext-contactus`; the root `core` package (which
  `coretypes` now imports for `IsAlphanumericOrUnderscore`) does not import
  `coretypes` back.

## Coverage

- `coretypes` package: 39.4% → 59.9% (measured via `git stash -u` before/after).
- Whole repo: 54.0% → 56.6%.
- Every promoted function is at 100% line coverage individually (`ID`,
  `String`, `DocID`, `Validate`, `NewFullItemRef`, `NewItemRefSameSpace`,
  `NewItemRefFromQueryString`, `NewSpaceKey`, `NewSpaceModuleKey`,
  `ValidateSpaceID`).
- This repo's CI (`ci.yml` → `strongo/cicd` `workflow.yml`) does not set
  `min_test_coverage_percent`, so there is no hard blocking coverage floor
  here (unlike `ext-*/backend` contract libs or `trackus/backend`) — Coveralls
  upload is informational only. No guard was cut to land this.

## Tagging

This repo **auto-tags on merge to main**: the shared `strongo/cicd`
`workflow.yml`'s `go_bump` job runs unconditionally on `github.ref ==
'refs/heads/main'` (no `disable-version-bumping` input set in this repo's
`ci.yml`), computing the next SemVer via git-cliff from conventional commit
messages and pushing the tag itself. This PR's `feat:`-prefixed title will
trigger at least a minor bump automatically once merged — no manual tag step
needed before steps 2/3 can consume it.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (real compile check for `_test.go` files, since `go
      build` skips them)
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go mod tidy` — no diff to `go.mod`/`go.sum`
- [x] `gofmt -l coretypes/` — clean
- [x] Nested `convospec` module (`GOWORK=off`): build/vet/test pass, still
      dependency-free
- [x] Confirmed `sneat-core-modules`/`ext-contactus` untouched
      (`git diff` scoped to this repo only)

https://claude.ai/code/session_01Bi98CKyubejZjnUL2CsZfH