### PR TITLE
feat(coretypes): add community-center space type (NoticeBoard.cc)

### DIFF
--- a/coretypes/space_type.go
+++ b/coretypes/space_type.go
@@ -41,6 +41,11 @@ const (
 	// subscriptions, not members; moderators may become members in a later
 	// phase.
 	SpaceTypeSpot SpaceType = "spot"
+
+	// SpaceTypeCommunityCentre is a community-centre / local-venue space type,
+	// used by NoticeBoard.cc (communitycentrum). Centre staff are members;
+	// public participants are customers (see Competios decision 0009).
+	SpaceTypeCommunityCentre SpaceType = "community-center"
 )
 
 // SpotSpaceIDPrefix is the reserved prefix used by SpotSpaceID to construct
@@ -117,7 +122,7 @@ func NewWeakSpaceRef(spaceType SpaceType) SpaceRef {
 // IsValidSpaceType checks if space has a valid/known type
 func IsValidSpaceType(v SpaceType) bool {
 	switch v {
-	case SpaceTypePersonal, SpaceTypeFamily, SpaceTypeGroup, SpaceTypeCompany, SpaceTypeSpace, SpaceTypeClub, SpaceTypeSystem, SpaceTypeSpot:
+	case SpaceTypePersonal, SpaceTypeFamily, SpaceTypeGroup, SpaceTypeCompany, SpaceTypeSpace, SpaceTypeClub, SpaceTypeSystem, SpaceTypeSpot, SpaceTypeCommunityCentre:
 		return true
 	default:
 		return false


### PR DESCRIPTION
Adds the `community-center` space type used by NoticeBoard.cc (`communitycentrum`).

- `coretypes/space_type.go`: new `SpaceTypeCommunityCentre = "community-center"` const + `IsValidSpaceType` case.
- Centre staff are members, public participants are customers (Competios decision 0009).

Enables `spaceus` `create_space` to accept a community-centre space once released + redeployed. gofmt/build/vet/test clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ouv1MtcisVDRQqa981w83