### PR TITLE
SpecScore + the slug-claims decision and feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 # Go workspace file
 go.work
 .DS_Store
+specscore.local.yaml

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,14 @@
+# Specifications
+
+SpecScore-formatted specifications for this project.
+
+## Contents
+
+| Directory | Purpose |
+|---|---|
+| [`features/`](features/README.md) | Feature specifications — one per sub-system |
+| [`ideas/`](ideas/README.md) | Pre-spec one-pagers exploring problem-direction-MVP |
+
+## Open Questions
+
+None at this time.

--- a/spec/decisions/0001-slug-claims.md
+++ b/spec/decisions/0001-slug-claims.md
@@ -1,0 +1,185 @@
+---
+format: https://specscore.md/decision-specification
+status: Draft
+---
+
+# Decision: One generic slug-claim package, namespaced
+
+**Status:** Draft
+**Date:** 2026-08-23
+**Owner:** alex
+**Tags:** slugs,dalgo,spaceus,bookius
+**Source Idea:** —
+**Supersedes:** —
+**Superseded By:** —
+
+## Context
+
+NoticeBoard.cc needs a public URL per centre — `noticeboard.cc/venue/<slug>` —
+which needs a globally unique, human-readable slug claimed against a space. Asked
+how to build it, the founder proposed a generic shared package rather than a
+local fix:
+
+> The implementation should be a generic shared package but allow registering a
+> unique slug for each extension separately. Something like
+> `/ext/<ext-id>/space-slugs/<space-slug>` → `.spaceID`.
+
+Looking for prior art turned up **two existing hand-rolled implementations of the
+same mechanism**, which settles the question of whether a shared package is
+warranted:
+
+- **`sneat-core-modules/spaceus`** — `getUniqueSpaceID` derives an ID from the
+  title's slug and claims it with a Get-then-take retry loop against the spaces
+  collection. It also *strips hyphens*, so "St Mary's Village Hall" becomes
+  `stmarysvillagehall`, and resolves a collision by appending `_` and a random
+  character.
+- **`sneat-co/bookius`** — a dedicated collection `bookiusBookingTypeSlugs`, whose
+  own doc comment reads *"the atomic (spaceID, slug) uniqueness index for booking
+  types: a composite-key document, never queried, only inserted-or-conflicts
+  inside the same transaction as the type itself"*, with a sentinel
+  `ErrBookingTypeSlugTaken` surfaced as HTTP 409.
+
+Both are correct. Both are the same idea written twice. A third was about to be
+written for space slugs.
+
+## Decision
+
+**One generic slug-claim package in `sneat-go-core`, keyed by an opaque
+namespace.**
+
+```
+/slugs/<namespace>/claims/<slug>  →  { targetID, targetKind, claimedAt, claimedBy }
+```
+
+- The **document ID is the lock.** A claim is taken by an insert that fails if the
+  document exists. This is the only shape that is atomic without depending on a
+  read.
+- The **namespace is an opaque string**, not a fixed "space" concept, so the same
+  package serves every uniqueness scope in the fleet:
+
+  | Namespace | Uniqueness |
+  |---|---|
+  | `communitycentrum:space` | global — the public `/venue/<slug>` case |
+  | `bookius:bookingType:<spaceID>` | per space — the existing index |
+  | `communitycentrum:room:<spaceID>` | per venue — rooms below the venue URL |
+
+- The **claim and the record are written in one transaction.** A claim without its
+  record, or a record without its claim, is a defect the package must make
+  impossible for callers to produce.
+- **The slug is stored on the record too.** The claim document answers slug →
+  targetID for routing; the record answers targetID → slug for rendering canonical
+  URLs without a query.
+- **Slugs are normalised before claiming** — lowercased, Unicode-normalised,
+  hyphens collapsed — so two claims cannot render identically.
+- **A reserved-word list** ships with the package and is extensible per namespace.
+- **Releasing a slug leaves a tombstone**, not a free slot.
+
+The package lives in **`sneat-go-core`**, not in `spaceus`.
+
+## Rationale
+
+Namespacing by an opaque string rather than by extension is the one change from
+the founder's sketch, and it is what lets the package absorb the prior art instead
+of sitting beside it. Bookius' scope is *(space, slug)*; rooms will want *(venue,
+slug)*; space slugs are global. An extension-only key expresses the third and not
+the first two, so Bookius would have kept its own index and the duplication this
+decision exists to remove would have survived it. `communitycentrum:space` is
+simply the case where the namespace happens to name only an extension.
+
+Extension scoping remains right for the space case specifically, because it
+**mirrors the URL namespace exactly**: `noticeboard.cc/venue/…` is already scoped
+by domain plus path segment, so one product's slugs cannot collide with another's.
+
+`sneat-go-core` rather than `spaceus` because booking-type slugs have nothing to
+do with spaces. Putting a generic claim mechanic behind the space module would
+make Bookius import `spaceus` in order to claim a slug for a booking type, which
+inverts the dependency for no reason.
+
+The three rules that look like polish are the ones that fail in production:
+
+**Tombstones.** A slug that has been printed on a village-hall poster must never
+be handed to a different trust. Releasing into the free pool means last year's
+poster silently starts sending people to someone else's hall — a failure that
+cannot be detected from inside the system and cannot be retrofitted once posters
+exist. Renaming therefore leaves a tombstone that redirects and blocks re-claiming.
+
+**Reserved words.** `/venue/new`, `/venue/admin`, `/venue/api`, `/venue/robots.txt`.
+Without a reserved list the first centre called "New" breaks routing, and the fix
+after the fact requires taking someone's URL away.
+
+**Normalisation.** `St-Marys` and `st-marys` are different document IDs that render
+identically. In a private namespace that is a collision bug; in a public one it is
+a phishing vector.
+
+## Declined Alternatives
+
+### Extension-keyed only, per the original sketch
+
+`/ext/<ext-id>/space-slugs/<slug>`. Structurally correct — document-ID-as-lock,
+per-extension namespacing, claim in the same transaction — and it is what this
+decision keeps. Declined only in its **fixed `space-slugs` leaf**, which cannot
+express Bookius' per-space scope or rooms' per-venue scope, so the duplication
+would have remained.
+
+### A flat collection with a composite ID
+
+`/slugs/<namespace>:<slug>`. One collection to secure, one rule to write.
+Declined because listing every slug in a namespace then needs a separate indexed
+field, whereas the nested form is an ordinary subcollection listing — and
+enumerating a namespace is exactly what an admin surface and any migration need.
+
+### Leaving each consumer to roll its own
+
+The status quo, and it demonstrably works twice. Declined under the standing rule
+that a gap in our own tooling is fixed upstream and consumed, not reimplemented
+per consumer. Two correct implementations already differ in their error type,
+their collision behaviour and their normalisation; a third would differ again, and
+none of them can be fixed once for everyone.
+
+### Putting it in `spaceus`
+
+Closest to where the immediate need arose. Declined because it would force every
+extension claiming a slug for a non-space thing to depend on the space module.
+
+## Consequences at Decision Time
+
+**Expected to follow:**
+
+- Bookius' `bookiusBookingTypeSlugs` index, `ErrBookingTypeSlugTaken` and its
+  transactional claim collapse into calls to the package, behind its existing HTTP
+  409 contract. Its data needs migrating into the new collection.
+- `spaceus` gains a **public slug** claimed through the package. See below for what
+  deliberately does *not* change.
+- The package's atomicity has to be provable in tests. The in-memory dalgo adapter
+  serialises every read-write transaction under one global lock, so a contention
+  test written against it passes without proving anything — being addressed
+  separately in `dal-go/dalgo`.
+
+**Costs accepted:**
+
+- A migration for Bookius' existing claims, which must run before its old index is
+  removed, not after.
+- Tombstones make the namespace monotonically grow. That is the intended trade:
+  storage is cheap, a mis-resolving printed URL is not.
+- One more shared package whose bugs are everyone's bugs.
+
+**Deliberately NOT changed:** `spaceus`' `getUniqueSpaceID`. It *generates* an ID
+with automatic collision suffixes; the package *claims* a caller-supplied slug and
+fails on conflict. These are different contracts, and every Sneat space ID in
+existence comes from the former — changing it is a fleet-wide blast radius nobody
+asked for. `spaceus` gains a public slug alongside its ID; the ID keeps its
+behaviour.
+
+**Deliberately left open:** how long a tombstone lives, and what a second
+"St Mary's Village Hall" is offered.
+
+## Observed Consequences
+
+None observed yet.
+
+## Affected Features
+
+- `slug-claims` — the package this decision creates.
+
+---
+*This document follows the https://specscore.md/decision-specification*

--- a/spec/decisions/README.md
+++ b/spec/decisions/README.md
@@ -1,0 +1,18 @@
+---
+format: https://specscore.md/decisions-index-specification
+---
+
+# Decisions
+
+## Decisions
+
+| # | Decision | Status | Date | Tags | Affected |
+|---|----------|--------|------|------|----------|
+| [0001](0001-slug-claims.md) | One generic slug-claim package, namespaced | Draft | 2026-08-23 | slugs,dalgo,spaceus,bookius | `slug-claims` — the package this decision creates. |
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/decisions-index-specification*

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -1,0 +1,20 @@
+---
+format: https://specscore.md/features-index-specification
+---
+
+# Features
+
+Feature specifications for this project.
+
+## Index
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| [Slug claims](slug-claims/README.md) | Draft | A shared package for claiming human-readable slugs uniquely, whatever they name. |
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/features-index-specification*

--- a/spec/features/slug-claims/README.md
+++ b/spec/features/slug-claims/README.md
@@ -1,0 +1,243 @@
+---
+format: https://specscore.md/feature-specification
+status: Draft
+---
+
+# Feature: Slug claims
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/sneat-co/sneat-go-core/spec/features/slug-claims?op=explore) | [Edit](https://specscore.studio/app/github.com/sneat-co/sneat-go-core/spec/features/slug-claims?op=edit) | [Ask question](https://specscore.studio/app/github.com/sneat-co/sneat-go-core/spec/features/slug-claims?op=ask) | [Request change](https://specscore.studio/app/github.com/sneat-co/sneat-go-core/spec/features/slug-claims?op=request-change) |
+**Status:** Draft
+**Source Ideas:** —
+
+## Summary
+
+A shared package for claiming human-readable slugs uniquely, whatever they name.
+A claim is a document whose **ID is the slug**, under an opaque **namespace**:
+
+```
+/slugs/<namespace>/claims/<slug>  →  { targetID, targetKind, claimedAt, claimedBy }
+```
+
+The document ID is the lock, so claiming is atomic without depending on a read.
+Callers claim inside **their own transaction**, alongside the record the slug
+names, so a claim and its record are never written apart. Slugs are normalised
+and checked against reserved words before they are claimed, and releasing one
+leaves a **tombstone** rather than a free slot.
+
+Per [Decision 0001](../../decisions/0001-slug-claims.md).
+
+## Problem
+
+The same mechanism has already been written twice in this fleet, differently each
+time. `spaceus` claims space IDs with a Get-then-take retry loop that strips
+hyphens and appends `_` plus a random character on collision. `bookius` keeps a
+dedicated `bookiusBookingTypeSlugs` collection, claimed by insert inside the
+caller's transaction, with its own sentinel error. Both work; neither can be fixed
+for the other; a third was about to be written for NoticeBoard's public venue URLs.
+
+The parts that get written twice are the easy parts. The parts that get skipped are
+the ones that fail later, in public:
+
+- A slug that has been **printed on a poster** and then released to a different
+  owner sends real people to the wrong place, and nothing inside the system can
+  detect it.
+- An unreserved namespace lets the first thing called **"new"** or **"admin"**
+  break routing, and the fix takes someone's URL away after they have used it.
+- Unnormalised slugs let `St-Marys` and `st-marys` both be claimed while rendering
+  identically — a collision bug in private, a phishing vector in public.
+
+## Behavior
+
+### The document ID is the lock
+
+#### REQ: claim-is-atomic
+
+Claiming a slug MUST be performed by an **insert that fails when the document
+already exists**, at `/slugs/<namespace>/claims/<slug>`. The package MUST NOT rely
+on a preceding read to establish uniqueness: a read-then-write is only safe under a
+backend that detects the conflict, and the package must be correct without assuming
+it. A failed claim MUST return an error identifiable by an exported predicate
+(`IsSlugTaken` or equivalent), so callers can map it to their own contract — for
+example Bookius' HTTP 409.
+
+#### REQ: claim-joins-the-caller-transaction
+
+The claim MUST be written inside a transaction **supplied by the caller**, so the
+claim and the record the slug names commit together or not at all. The package MUST
+NOT open its own transaction for a claim, and MUST NOT offer an API shape whose
+natural use writes the claim separately from the record.
+
+### Namespaces are opaque
+
+#### REQ: namespace-is-opaque
+
+The namespace MUST be an arbitrary caller-supplied string, not a fixed concept, so
+one package serves a global scope (`communitycentrum:space`), a per-space scope
+(`bookius:bookingType:<spaceID>`) and a per-parent scope
+(`communitycentrum:room:<spaceID>`) identically. The package MUST validate that a
+namespace is non-empty and safe as a document ID, and MUST be able to **enumerate
+every claim in a namespace**, which admin surfaces and migrations both need.
+
+### Slugs are normalised before they are claimed
+
+#### REQ: normalisation
+
+A slug MUST be normalised before it is claimed or resolved: Unicode-normalised,
+lowercased, with runs of separators collapsed and leading/trailing separators
+removed. Two inputs that normalise to the same string MUST resolve to the same
+claim rather than to two claims. The normalised form MUST be what is stored and
+what appears in URLs, and the package MUST expose the normaliser so callers can
+show a user the slug they will actually get before they commit to it.
+
+#### REQ: reserved-words
+
+The package MUST carry a base list of reserved slugs that cannot be claimed in any
+namespace — at least `new`, `edit`, `admin`, `api`, `static`, `assets`, `robots`,
+`sitemap`, `favicon`, `well-known` — and MUST let a caller extend it per namespace.
+An attempt to claim a reserved slug MUST fail with an error distinguishable from
+*taken*, because the remedy differs: one is "choose another name", the other is
+"someone already has this".
+
+### Resolving
+
+#### REQ: resolve
+
+The package MUST resolve a `(namespace, slug)` to its `targetID` and `targetKind`
+in a single read, with no query. Resolving a slug that has never been claimed and
+resolving one that is **tombstoned** MUST be distinguishable, since the first is a
+404 and the second is a redirect.
+
+### Release leaves a tombstone
+
+#### REQ: release-leaves-tombstone
+
+Releasing a claim — on rename, or when the target is deleted — MUST leave a
+**tombstone** at the same document, recording what it previously pointed to and
+when it was released, rather than deleting the document. A tombstoned slug MUST NOT
+be claimable by a different target. Renaming MUST record the **new** slug on the
+tombstone so callers can issue a redirect. The package MUST provide rename as a
+single operation that claims the new slug and tombstones the old one in the
+caller's transaction, so a rename cannot half-happen.
+
+## Acceptance Criteria
+
+### AC: second-claim-is-refused (verifies REQ:claim-is-atomic)
+
+**Scenario:** a slug is claimed once
+**Given** an empty namespace
+**When** two claims of the same normalised slug are attempted
+**Then** the first succeeds and the second fails with an error for which the exported *taken* predicate returns true.
+
+### AC: concurrent-claims-yield-one-winner (verifies REQ:claim-is-atomic)
+
+**Scenario:** two registrations race for the same name
+**Given** a backend that surfaces write conflicts
+**When** two transactions concurrently claim the same slug in the same namespace
+**Then** exactly one commits and the other fails as *taken* or as a retryable conflict, and there is no state in which both hold the claim.
+
+### AC: claim-and-record-commit-together (verifies REQ:claim-joins-the-caller-transaction)
+
+**Scenario:** no orphan claims
+**Given** a caller transaction that claims a slug and then fails before commit
+**When** the transaction is rolled back
+**Then** no claim document exists — the slug is free.
+
+### AC: namespaces-are-independent (verifies REQ:namespace-is-opaque)
+
+**Scenario:** the same slug in two namespaces
+**Given** namespaces `a:space` and `b:space`
+**When** the slug `main-hall` is claimed in each
+**Then** both succeed and each resolves to its own target.
+
+### AC: namespace-can-be-enumerated (verifies REQ:namespace-is-opaque)
+
+**Scenario:** an admin lists what is claimed
+**Given** a namespace holding several claims and a tombstone
+**When** the namespace is enumerated
+**Then** every claim is returned, with tombstones distinguishable from live claims.
+
+### AC: equivalent-inputs-normalise-together (verifies REQ:normalisation)
+
+**Scenario:** case and separators do not create a second claim
+**Given** the slug `St--Marys Village Hall ` claimed in a namespace
+**When** `st-marys-village-hall` is claimed in the same namespace
+**Then** it is refused as taken, and both inputs resolve to the same target.
+
+### AC: reserved-slug-is-refused-distinctly (verifies REQ:reserved-words)
+
+**Scenario:** a centre called "New"
+**Given** an empty namespace
+**When** the slug `new` is claimed
+**Then** it is refused with an error distinguishable from *taken*; and a namespace-specific extra reserved word behaves the same way.
+
+### AC: resolve-returns-target-in-one-read (verifies REQ:resolve)
+
+**Scenario:** routing a public URL
+**Given** a claimed slug
+**When** it is resolved
+**Then** its `targetID` and `targetKind` are returned from a single document read with no query.
+
+### AC: unclaimed-and-tombstoned-are-distinguishable (verifies REQ:resolve)
+
+**Scenario:** 404 versus redirect
+**Given** one slug never claimed and one tombstoned by a rename
+**When** each is resolved
+**Then** the first reports *not found* and the second reports a tombstone carrying the new slug.
+
+### AC: renamed-slug-is-not-reusable (verifies REQ:release-leaves-tombstone)
+
+**Scenario:** last year's poster keeps working, and cannot be hijacked
+**Given** a target renamed from `st-marys-village-hall` to `st-marys-hall`
+**When** a different target attempts to claim `st-marys-village-hall`
+**Then** it is refused, and resolving the old slug reports a tombstone naming the new one.
+
+### AC: rename-is-atomic (verifies REQ:release-leaves-tombstone)
+
+**Scenario:** a rename cannot half-happen
+**Given** a rename whose caller transaction fails before commit
+**When** the transaction is rolled back
+**Then** the old slug still resolves to the target and the new slug is unclaimed.
+
+## Architecture & Dependencies
+
+- **Home** — `sneat-go-core`, not `spaceus`: booking-type slugs have nothing to do
+  with spaces, and a generic mechanic behind the space module would make Bookius
+  depend on `spaceus` to claim a slug.
+- **Storage** — dalgo, `/slugs/<namespace>/claims/<slug>`; the claim is written with
+  an insert on a caller-supplied `dal.ReadwriteTransaction`.
+- **Prior art being consolidated** — `bookius`' `bookiusBookingTypeSlugs` +
+  `ErrBookingTypeSlugTaken` (a faithful instance of this pattern, to be migrated),
+  and `spaceus`' `getUniqueSpaceID` (a *different* contract — ID generation with
+  automatic collision suffixes — which is deliberately **not** changed; `spaceus`
+  gains a public slug alongside its ID).
+- **Testing** — the in-memory dalgo adapter serialises every read-write transaction
+  under one global lock, so `concurrent-claims-yield-one-winner` cannot be proved
+  against it as it stands. That is being addressed in `dal-go/dalgo` separately;
+  until it lands, that AC is provable only against an emulator or a real backend,
+  and MUST NOT be marked satisfied by a test that would pass regardless.
+
+## Not Doing
+
+- **Generating slugs.** The package claims a slug the caller supplies and refuses a
+  taken one; it does not invent alternatives or append suffixes.
+- **Changing `spaceus`' space-ID generation** — different contract, fleet-wide blast
+  radius, nobody asked.
+- **Serving redirects.** The package reports a tombstone and its successor; issuing
+  the 301 is the caller's routing concern.
+- **Expiring tombstones automatically** — see Open Questions.
+- **Confusable/homoglyph detection** beyond Unicode normalisation.
+
+## Open Questions
+
+- **How long does a tombstone live?** Forever is safest and grows the namespace
+  monotonically; anything shorter needs a defensible number, and the risk is
+  asymmetric — a released slug that a poster still points at sends people to the
+  wrong hall.
+- **What is a second "St Mary's Village Hall" offered?** The package refuses rather
+  than inventing, so the answer belongs to callers — but if every caller writes its
+  own suggestion logic, that is this decision's problem all over again.
+- **Should a claim record who holds it** beyond `claimedBy`, and should the package
+  enforce that only that holder may release it, or is that the caller's ACL?
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -1,0 +1,19 @@
+---
+format: https://specscore.md/ideas-index-specification
+---
+
+# Ideas
+
+Pre-spec one-pagers. Each Idea is a lint-clean problem-direction-MVP one-pager that may later promote into one or more SpecScore Features under [`features/`](../features/README.md).
+
+## Index
+
+| Idea | Status | Date | Owner | Promotes To |
+|------|--------|------|-------|-------------|
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/ideas-index-specification*

--- a/specscore.yaml
+++ b/specscore.yaml
@@ -1,0 +1,7 @@
+# SpecScore Repo Config Schema: https://specscore.md/repo-config
+
+project:
+    title: Sneat Go Core
+    host: github.com
+    org: sneat-co
+    repo: sneat-go-core


### PR DESCRIPTION
Specs for the generic slug-claim package, agreed in conversation. Docs-only; also initialises SpecScore in this repo, which had none.

## Why a shared package is justified

Looking for prior art is what settled it — **the same mechanism already exists twice**, written differently:

| Where | How |
|---|---|
| `sneat-core-modules/spaceus` | `getUniqueSpaceID` — Get-then-take retry loop, strips hyphens, appends `_` + random char on collision |
| `sneat-co/bookius` | `bookiusBookingTypeSlugs` — claimed by insert inside the caller's transaction, `ErrBookingTypeSlugTaken` → HTTP 409 |

Both correct. Neither fixable for the other. A third was about to be written for NoticeBoard's `/venue/<slug>` URLs.

## The shape

```
/slugs/<namespace>/claims/<slug>  →  { targetID, targetKind, claimedAt, claimedBy }
```

The one change from the founder's original sketch is an **opaque namespace** instead of a fixed `space-slugs` leaf — and it is the change that lets the package absorb the prior art rather than sit beside it:

| Namespace | Uniqueness |
|---|---|
| `communitycentrum:space` | global — the public `/venue/<slug>` case |
| `bookius:bookingType:<spaceID>` | per space — the existing index |
| `communitycentrum:room:<spaceID>` | per venue |

An extension-only key expresses the first and not the other two, so Bookius would have kept its own index and the duplication would have survived the exercise.

`sneat-go-core` rather than `spaceus`, because booking-type slugs have nothing to do with spaces — putting the mechanic behind the space module would make Bookius import `spaceus` to claim a slug for a booking type.

## The three rules that look like polish

They are the ones that fail in public, so they are REQs rather than notes:

- **Tombstones** — a slug printed on a village-hall poster must never be handed to a different trust. Releasing into the free pool means last year's poster silently sends people to someone else's hall, and nothing inside the system can detect it. Cannot be retrofitted once posters exist.
- **Reserved words** — or the first centre called "New" breaks routing, and the fix takes someone's URL away afterwards.
- **Normalisation** — `St-Marys` and `st-marys` are two document IDs that render identically. Collision bug in private, phishing vector in public.

## Deliberately not changed

`spaceus`' `getUniqueSpaceID`. It **generates** an ID with automatic collision suffixes; the package **claims** a caller-supplied slug and fails on conflict. Different contracts — and every Sneat space ID in existence comes from the former, so changing it is a fleet-wide blast radius nobody asked for. `spaceus` gains a public slug *alongside* its ID.

## One testing constraint recorded up front

`dalgo2memory` serialises every read-write transaction under a global lock, so the `concurrent-claims-yield-one-winner` AC **cannot be proved against it** as it stands — a test would pass without demonstrating anything. The Feature says so explicitly and forbids marking that AC satisfied by such a test. Being addressed separately in `dal-go/dalgo`.

`specscore spec lint` → 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)