### PR TITLE
Report ErrSlugTaken only for a genuine duplicate key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.24.3
 
 require (
 	github.com/crediterra/money v0.3.5
-	github.com/dal-go/dalgo v0.65.0
+	github.com/dal-go/dalgo v0.66.0
 	github.com/stretchr/testify v1.12.1
 	github.com/strongo/analytics v0.2.5
 	github.com/strongo/delaying v0.2.3
@@ -25,7 +25,7 @@ require (
 	github.com/RoaringBitmap/roaring/v2 v2.25.0 // indirect
 	github.com/alexsergivan/transliterator v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.6 // indirect
-	github.com/dal-go/record v0.1.2
+	github.com/dal-go/record v0.1.3
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/strongo/decimal v0.1.2 // indirect
 	github.com/strongo/random v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,10 @@ github.com/bits-and-blooms/bitset v1.24.6 h1:qcrftZUVBIwfs+m+nhoCBAPT+ZPZZjti8Sb
 github.com/bits-and-blooms/bitset v1.24.6/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/crediterra/money v0.3.5 h1:H59COTzKEtRbl8Wlr2tNYWnBkoMOdOrEPVhGYez+VGU=
 github.com/crediterra/money v0.3.5/go.mod h1:0BT7dzPk4Wv+Wi8J6sxlFbCknYioLWVVQM4ciMJh6TI=
-github.com/dal-go/dalgo v0.65.0 h1:Ugpj/Rxf5cZunvKZnhrC7ba06gQoDQuC0uYCcLNSnx0=
-github.com/dal-go/dalgo v0.65.0/go.mod h1:pz5Xda/ItwamcBsbUyKOESb68gVfcdCHuCdxa2cf+T0=
-github.com/dal-go/record v0.1.2 h1:cDy296wwG3r2T+vy0yVJBouJ936oISiqiNB7G3ef5Og=
-github.com/dal-go/record v0.1.2/go.mod h1:quwsVJTT0f6y3Mhx+yHpTobY7luX1M6kyO6fdJ/AFYE=
+github.com/dal-go/dalgo v0.66.0 h1:gesurCrEK57wiTCaaw8PhGM/Y7wViXaXPxcF1Td4AeU=
+github.com/dal-go/dalgo v0.66.0/go.mod h1:2siY9rsHk+pQnZcJhac2B4QM9gQYbjzV+TJAYEUh6Ng=
+github.com/dal-go/record v0.1.3 h1:K85k/kSX08lTefMiMmPpC12nmCY2TVJk7+ZyC5PD9XU=
+github.com/dal-go/record v0.1.3/go.mod h1:quwsVJTT0f6y3Mhx+yHpTobY7luX1M6kyO6fdJ/AFYE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
 github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=

--- a/slugs/claim.go
+++ b/slugs/claim.go
@@ -32,14 +32,23 @@ import (
 // store the exact string that was claimed rather than re-deriving it.
 //
 // Claim never reads before it writes: the only database operation it performs
-// is a single tx.Insert at the claim's fixed document ID. Insert failing is
-// therefore reported as ErrSlugTaken unconditionally — there is no cross-
-// backend sentinel in dalgo for "insert failed because the document already
-// exists" (adapters currently return a plain error), but at a key this
-// package has already validated, an insert's only expected failure mode is
-// that the document is already there. This mirrors Bookius'
-// ErrBookingTypeSlugTaken, the prior art this package is consolidating (see
-// Decision 0001).
+// is a single tx.Insert at the claim's fixed document ID, which is what makes
+// the claim atomic without depending on a read.
+//
+// A failed insert is reported as ErrSlugTaken only when the adapter identifies
+// it as a duplicate key, via record.IsAlreadyExists. Any other failure is
+// returned as itself. The distinction matters to end users: reporting every
+// insert failure as "taken" tells someone their chosen name is unavailable
+// when the real problem was a deadline or a permission error, and sends them
+// off to invent a different name for no reason.
+//
+// Note the asymmetry: record.IsAlreadyExists returning false is NOT proof that
+// the key was free. An adapter that does not classify its duplicate-key errors
+// never returns the sentinel, so against one of those a genuine conflict
+// surfaces as a plain error rather than ErrSlugTaken. That is the safer
+// direction to fail — an honest error beats a confident wrong answer — and it
+// is a visible, tracked state rather than a silent one, because dalgo's shared
+// conformance suite has an unconditional check for exactly this behaviour.
 func Claim(ctx context.Context, tx dal.ReadwriteTransaction, namespace Namespace, slug, targetID string, targetKind TargetKind, opts ...Option) (Slug, error) {
 	if err := ValidateNamespace(namespace); err != nil {
 		return "", err
@@ -62,7 +71,10 @@ func Claim(ctx context.Context, tx dal.ReadwriteTransaction, namespace Namespace
 	}
 	rec := record.NewRecordWithData(claimKey(namespace, Slug(normalised)), data)
 	if err := tx.Insert(ctx, rec); err != nil {
-		return "", fmt.Errorf("%w: %q in namespace %q: %w", ErrSlugTaken, normalised, namespace, err)
+		if record.IsAlreadyExists(err) {
+			return "", fmt.Errorf("%w: %q in namespace %q: %w", ErrSlugTaken, normalised, namespace, err)
+		}
+		return "", fmt.Errorf("slugs: claiming %q in namespace %q: %w", normalised, namespace, err)
 	}
 	return Slug(normalised), nil
 }

--- a/slugs/claim_test.go
+++ b/slugs/claim_test.go
@@ -187,3 +187,37 @@ func TestClaim_ReservedSlugIsRefusedDistinctly(t *testing.T) {
 		t.Errorf("\"default\" should not be reserved outside the namespace that extended the list: %v", err)
 	}
 }
+
+// TestClaim_NonDuplicateFailureIsNotReportedAsTaken verifies that a failed
+// insert which is NOT a duplicate key is returned as itself rather than as
+// ErrSlugTaken.
+//
+// This is the regression this test exists to prevent. Claim used to report
+// every insert failure as ErrSlugTaken, because dalgo had no cross-backend
+// sentinel for "already exists". The visible symptom was a user being told
+// their chosen name was taken when the real problem was a deadline or a
+// permission error — sending them off to invent a different name for no
+// reason. Bookius inherited that when it migrated onto this package; its
+// hand-rolled predecessor had distinguished the two correctly.
+//
+// The non-duplicate failure here is induced with a schema that forbids
+// undefined collections, so the insert is rejected by the collection guard
+// long before anything could be duplicated.
+func TestClaim_NonDuplicateFailureIsNotReportedAsTaken(t *testing.T) {
+	db := dalgo2memory.NewDB(dalgo2memory.WithSchema(false))
+	ctx := context.Background()
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		_, err := slugs.Claim(ctx, tx, "test:space", "Main Hall", "space-1", "space")
+		return err
+	})
+	if err == nil {
+		t.Fatal("expected the guarded insert to fail, got nil")
+	}
+	if slugs.IsSlugTaken(err) {
+		t.Errorf("IsSlugTaken(%v) = true, want false: a non-duplicate failure must not read as a taken slug", err)
+	}
+	if errors.Is(err, slugs.ErrSlugTaken) {
+		t.Errorf("errors.Is(%v, ErrSlugTaken) = true, want false", err)
+	}
+}

--- a/spec/features/slug-claims/README.md
+++ b/spec/features/slug-claims/README.md
@@ -58,7 +58,18 @@ on a preceding read to establish uniqueness: a read-then-write is only safe unde
 backend that detects the conflict, and the package must be correct without assuming
 it. A failed claim MUST return an error identifiable by an exported predicate
 (`IsSlugTaken` or equivalent), so callers can map it to their own contract — for
-example Bookius' HTTP 409.
+example Bookius' HTTP 409. That error MUST be returned **only** when the adapter
+identifies the failure as a duplicate key (`record.IsAlreadyExists`); every other
+insert failure MUST be returned as itself. Reporting an unclassified failure as
+*taken* tells a user their chosen name is unavailable when the real problem was a
+deadline or a permission error.
+
+The asymmetry MUST be respected: `record.IsAlreadyExists` returning false is **not**
+proof the key was free. An adapter that does not classify duplicates never returns
+the sentinel, so against one of those a genuine conflict surfaces as a plain error
+rather than as *taken*. That is the safer direction to fail, and it is a tracked
+state rather than a silent one — dalgo's shared conformance suite carries an
+unconditional check for this behaviour.
 
 #### REQ: claim-joins-the-caller-transaction
 
@@ -134,6 +145,13 @@ caller's transaction, so a rename cannot half-happen.
 **Given** a backend that surfaces write conflicts
 **When** two transactions concurrently claim the same slug in the same namespace
 **Then** exactly one commits and the other fails as *taken* or as a retryable conflict, and there is no state in which both hold the claim.
+
+### AC: non-duplicate-failure-is-not-taken (verifies REQ:claim-is-atomic)
+
+**Scenario:** a backend problem is not a naming problem
+**Given** an insert that fails for a reason other than a duplicate key
+**When** a slug is claimed
+**Then** the error is returned as itself, `IsSlugTaken` reports false, and the caller is not told the slug is taken.
 
 ### AC: claim-and-record-commit-together (verifies REQ:claim-joins-the-caller-transaction)
 


### PR DESCRIPTION
Closes the error-fidelity regression that bookius inherited when it migrated onto this package.

## The bug

`Claim` reported **every** `tx.Insert` failure as `ErrSlugTaken`, because dalgo had no cross-backend sentinel for "already exists". So a deadline-exceeded or permission error told a user their chosen name was taken — and sent them off to invent a different one for no reason.

Bookius' hand-rolled predecessor distinguished the two correctly (`Get` → found means taken; any other error is a real failure). Consolidating onto the shared package lost that. **Bookius needs no change of its own to pick this up.**

## The fix

`record.ErrRecordExists` / `IsAlreadyExists` now exist in [`dal-go/record` v0.1.3](https://github.com/dal-go/record/releases/tag/v0.1.3), and both adapters Sneat actually uses return them:

- `dalgo2memory` — `dalgo` v0.66.0
- `dalgo2firestore` — v0.10.9, which classifies at the transaction **commit**, since a Firestore transactional write is buffered and never fails at `Create`

## The asymmetry, documented on `Claim`

`IsAlreadyExists` returning false is **not** proof the key was free. An adapter that does not classify duplicates never returns the sentinel, so against one of those a genuine conflict surfaces as a plain error rather than as *taken*.

That is deliberately the safer direction to fail — an honest error beats a confident wrong answer — and it is a **tracked** state rather than a silent one, because dalgo's shared conformance suite carries an unconditional check for exactly this behaviour.

## The test, and proof it can fail

`TestClaim_NonDuplicateFailureIsNotReportedAsTaken` induces a non-duplicate failure with a schema that forbids undefined collections. Reverting the fix makes it fail with:

```
IsSlugTaken(slugs: slug is already claimed: "main-hall" in namespace "test:space":
  collection "claims" is not defined in the schema) = true, want false
```

A schema error, reported as "slug already claimed" — the bug in miniature.

## Also

- `record` v0.1.2 → v0.1.3, `dalgo` v0.65.0 → v0.66.0
- Feature spec updated: `REQ:claim-is-atomic` now states the narrowing and the asymmetry; new `AC:non-duplicate-failure-is-not-taken`. `specscore spec lint` → 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)