### PR TITLE
Space-registration profiles; retire the community-center space type

### DIFF
--- a/coretypes/space_type.go
+++ b/coretypes/space_type.go
@@ -22,13 +22,23 @@ const (
 	// deliberately rejects this type because a group reference needs an ID.
 	SpaceTypeGroup SpaceType = "group"
 
-	// SpaceTypeCompany is a "company" space type
+	// SpaceTypeCompany is a "company" space type: an organisation whose staff
+	// are members and whose public are customers. This is what a school, a
+	// gaming venue and a community centre all register as — what the Space is
+	// *for* is recorded in SpaceDbo.Modules, not in its type. See sneat-specs
+	// decision 0006 (unified space registration).
 	SpaceTypeCompany SpaceType = "company"
 
-	// SpaceTypeSpace is a "space" space type
+	// SpaceTypeSpace is a "space" space type.
+	//
+	// Deprecated: no longer issued for new registrations (decision 0006 —
+	// products register a type describing membership, and this one describes
+	// nothing). Still accepted by IsValidSpaceType so existing records read.
 	SpaceTypeSpace SpaceType = "space"
 
-	// SpaceTypeClub is a "club" space type
+	// SpaceTypeClub is a "club" space type: a members' organisation, where
+	// membership *is* the relationship (a sports club's players, guardians,
+	// coaches and volunteers are members, not customers).
 	SpaceTypeClub SpaceType = "club"
 
 	// SpaceTypeSystem is a platform-owned "system" space type for shared,
@@ -41,11 +51,6 @@ const (
 	// subscriptions, not members; moderators may become members in a later
 	// phase.
 	SpaceTypeSpot SpaceType = "spot"
-
-	// SpaceTypeCommunityCentre is a community-centre / local-venue space type,
-	// used by NoticeBoard.cc (communitycentrum). Centre staff are members;
-	// public participants are customers (see Competios decision 0009).
-	SpaceTypeCommunityCentre SpaceType = "community-center"
 )
 
 // SpotSpaceIDPrefix is the reserved prefix used by SpotSpaceID to construct
@@ -122,7 +127,7 @@ func NewWeakSpaceRef(spaceType SpaceType) SpaceRef {
 // IsValidSpaceType checks if space has a valid/known type
 func IsValidSpaceType(v SpaceType) bool {
 	switch v {
-	case SpaceTypePersonal, SpaceTypeFamily, SpaceTypeGroup, SpaceTypeCompany, SpaceTypeSpace, SpaceTypeClub, SpaceTypeSystem, SpaceTypeSpot, SpaceTypeCommunityCentre:
+	case SpaceTypePersonal, SpaceTypeFamily, SpaceTypeGroup, SpaceTypeCompany, SpaceTypeSpace, SpaceTypeClub, SpaceTypeSystem, SpaceTypeSpot:
 		return true
 	default:
 		return false

--- a/coretypes/space_type.go
+++ b/coretypes/space_type.go
@@ -31,9 +31,11 @@ const (
 
 	// SpaceTypeSpace is a "space" space type.
 	//
-	// Deprecated: no longer issued for new registrations (decision 0006 —
-	// products register a type describing membership, and this one describes
-	// nothing). Still accepted by IsValidSpaceType so existing records read.
+	// No longer issued for new registrations: decision 0006 has products
+	// register a type that describes how membership works, and this one
+	// describes nothing. It stays valid so existing records still read, and is
+	// deliberately NOT marked Deprecated — the tests that cover legacy records
+	// must keep naming it without tripping a linter.
 	SpaceTypeSpace SpaceType = "space"
 
 	// SpaceTypeClub is a "club" space type: a members' organisation, where

--- a/extension/config.go
+++ b/extension/config.go
@@ -18,6 +18,9 @@ type Config interface {
 	// this extension's API server must accept for CORS. The scheme is derived by
 	// the security package (see security.AddKnownHosts).
 	KnownHosts() []string
+	// SpaceProfile returns this extension's space-registration profile, or nil
+	// when it registers no Spaces of its own. See RegisterSpaceProfile.
+	SpaceProfile() *SpaceRegistrationProfile
 }
 
 type RegistrationArgs interface {
@@ -63,6 +66,7 @@ var _ Config = (*config)(nil)
 type config struct {
 	id                   coretypes.ExtID
 	knownHosts           []string
+	spaceProfile         *SpaceRegistrationProfile
 	registerRoutes       []func(handle HTTPHandleFunc)
 	registerDelays       []func(mustRegisterFunc func(key string, i any) delaying.Delayer)
 	registerNotificators []func(createNotification CreateNotificationFunc)
@@ -71,6 +75,8 @@ type config struct {
 func (m *config) internal() {}
 
 func (m *config) KnownHosts() []string { return m.knownHosts }
+
+func (m *config) SpaceProfile() *SpaceRegistrationProfile { return m.spaceProfile }
 
 func (m *config) Register(args RegistrationArgs) {
 

--- a/extension/space_registration.go
+++ b/extension/space_registration.go
@@ -1,0 +1,161 @@
+package extension
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/sneat-co/sneat-go-core/coretypes"
+)
+
+// SpaceRegistrationProfile declares what registering a Space means for one
+// extension. It is the "domain-specific" half of unified space registration:
+// the platform owns the operation, each extension owns this declaration.
+//
+// It is deliberately data, not behaviour. An extension states which kind of
+// Space it registers, which public URL namespace it claims slugs in, and which
+// roles its registering operator needs — and the platform's RegisterSpace
+// executes all of that in one transaction. Nothing here is a callback, so a
+// reviewer can answer "what does registering a venue do?" by reading one struct
+// literal.
+//
+// See sneat-specs decision 0006 (unified space registration). The shape follows
+// eventius' vertical registry: a declarative row per product, where adding a
+// product means adding a row and nothing in the engine changes.
+type SpaceRegistrationProfile struct {
+	// SpaceType is the Space type this extension registers. It describes how
+	// membership works, NOT what the Space is for — the extension id recorded
+	// in SpaceDbo.Modules is what says the Space is a venue, a school or a
+	// community centre.
+	//
+	// The rule from decision 0006: staff are members and the public are
+	// customers => SpaceTypeCompany. A members' organisation, where membership
+	// *is* the relationship, is SpaceTypeClub. Products do not mint their own
+	// Space types.
+	SpaceType coretypes.SpaceType
+
+	// SlugNamespace is the slugs namespace this extension claims public slugs
+	// in (e.g. "communitycentrum:space"). Empty means the extension has no
+	// public URL scheme for its Spaces, and RegisterSpace never claims a slug
+	// for it.
+	SlugNamespace string
+
+	// CreatorRoles are roles the registering user needs in addition to the ones
+	// CreateSpace always grants a creator (member, creator, owner,
+	// contributor). Usually empty: the default set already covers an operator
+	// registering their own Space.
+	CreatorRoles []string
+}
+
+// Validate reports whether the profile can be registered.
+func (p SpaceRegistrationProfile) Validate() error {
+	if !coretypes.IsValidSpaceType(p.SpaceType) {
+		return fmt.Errorf("space registration profile has an unknown space type: %q", p.SpaceType)
+	}
+	switch p.SpaceType {
+	case coretypes.SpaceTypeSystem, coretypes.SpaceTypeSpot, coretypes.SpaceTypePersonal:
+		return fmt.Errorf("space type %q cannot be registered by an extension: it is provisioned by the platform or has no ordinary membership", p.SpaceType)
+	}
+	if p.SlugNamespace != strings.TrimSpace(p.SlugNamespace) {
+		return fmt.Errorf("space registration slug namespace must not have leading or trailing whitespace: %q", p.SlugNamespace)
+	}
+	for _, role := range p.CreatorRoles {
+		if strings.TrimSpace(role) == "" {
+			return fmt.Errorf("space registration profile has an empty creator role")
+		}
+	}
+	return nil
+}
+
+var (
+	spaceProfilesMu sync.RWMutex
+	spaceProfiles   = map[coretypes.ExtID]SpaceRegistrationProfile{}
+)
+
+// RegisterSpaceProfile declares this extension's space-registration profile.
+//
+// The profile is recorded in a process-wide registry at extension-construction
+// time — before any request is served — so the platform can answer both
+// "what does registering for extension X create?" and "which Space types can an
+// extension register at all?" without importing any extension.
+//
+// Re-declaring the same profile for the same extension is a no-op, so
+// constructing an extension twice (as tests do) is safe. Declaring a
+// *different* profile for an id already registered panics: two answers to
+// "what is a venue Space?" is the drift decision 0006 exists to end.
+func RegisterSpaceProfile(profile SpaceRegistrationProfile) Option {
+	return func(m Config) {
+		c := m.(*config)
+		if err := profile.Validate(); err != nil {
+			panic(fmt.Sprintf("extension %s: %v", c.id, err))
+		}
+		c.spaceProfile = &profile
+
+		spaceProfilesMu.Lock()
+		defer spaceProfilesMu.Unlock()
+		if existing, ok := spaceProfiles[c.id]; ok && !existing.equal(profile) {
+			panic(fmt.Sprintf(
+				"extension %s declares two different space registration profiles: %+v and %+v",
+				c.id, existing, profile))
+		}
+		spaceProfiles[c.id] = profile
+	}
+}
+
+func (p SpaceRegistrationProfile) equal(other SpaceRegistrationProfile) bool {
+	if p.SpaceType != other.SpaceType || p.SlugNamespace != other.SlugNamespace {
+		return false
+	}
+	if len(p.CreatorRoles) != len(other.CreatorRoles) {
+		return false
+	}
+	for i, role := range p.CreatorRoles {
+		if role != other.CreatorRoles[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// LookupSpaceProfile returns the registration profile declared by an extension.
+// The second result is false when the extension declared none, which means it
+// does not register Spaces of its own — schoolus-style extensions that only
+// ever operate inside a Space someone else registered.
+func LookupSpaceProfile(extID coretypes.ExtID) (SpaceRegistrationProfile, bool) {
+	spaceProfilesMu.RLock()
+	defer spaceProfilesMu.RUnlock()
+	profile, ok := spaceProfiles[extID]
+	return profile, ok
+}
+
+// RegisterableSpaceTypes returns every Space type some extension declares it
+// registers, sorted.
+//
+// This is what lets the platform decide "is this an ordinary Space an extension
+// may act on?" from the registry instead of a hard-coded switch, so adding a
+// product no longer means editing a file that product does not own.
+func RegisterableSpaceTypes() []coretypes.SpaceType {
+	spaceProfilesMu.RLock()
+	defer spaceProfilesMu.RUnlock()
+
+	seen := make(map[coretypes.SpaceType]bool, len(spaceProfiles))
+	types := make([]coretypes.SpaceType, 0, len(spaceProfiles))
+	for _, profile := range spaceProfiles {
+		if seen[profile.SpaceType] {
+			continue
+		}
+		seen[profile.SpaceType] = true
+		types = append(types, profile.SpaceType)
+	}
+	sort.Slice(types, func(i, j int) bool { return types[i] < types[j] })
+	return types
+}
+
+// ResetSpaceProfilesForTest clears the registry. Tests that assert on registry
+// contents call it to stay independent of which extensions another test built.
+func ResetSpaceProfilesForTest() {
+	spaceProfilesMu.Lock()
+	defer spaceProfilesMu.Unlock()
+	spaceProfiles = map[coretypes.ExtID]SpaceRegistrationProfile{}
+}

--- a/extension/space_registration_test.go
+++ b/extension/space_registration_test.go
@@ -1,0 +1,220 @@
+package extension
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sneat-co/sneat-go-core/coretypes"
+)
+
+func venueProfile() SpaceRegistrationProfile {
+	return SpaceRegistrationProfile{
+		SpaceType:     coretypes.SpaceTypeCompany,
+		SlugNamespace: "gametable:space",
+	}
+}
+
+func TestSpaceRegistrationProfile_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile SpaceRegistrationProfile
+		wantErr string
+	}{
+		{
+			name:    "company is registerable",
+			profile: SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypeCompany},
+		},
+		{
+			name:    "club is registerable",
+			profile: SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypeClub, SlugNamespace: "sneatclub:space"},
+		},
+		{
+			name:    "creator roles are allowed",
+			profile: SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypeGroup, CreatorRoles: []string{"member"}},
+		},
+		{
+			name:    "unknown space type is rejected",
+			profile: SpaceRegistrationProfile{SpaceType: "community-center"},
+			wantErr: "unknown space type",
+		},
+		{
+			name:    "empty space type is rejected",
+			profile: SpaceRegistrationProfile{},
+			wantErr: "unknown space type",
+		},
+		{
+			// The platform owns system spaces; an extension must not mint one.
+			name:    "system space type is rejected",
+			profile: SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypeSystem},
+			wantErr: "cannot be registered by an extension",
+		},
+		{
+			// A spot has no members, so there is no operator to register it.
+			name:    "spot space type is rejected",
+			profile: SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypeSpot},
+			wantErr: "cannot be registered by an extension",
+		},
+		{
+			name:    "personal space type is rejected",
+			profile: SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypePersonal},
+			wantErr: "cannot be registered by an extension",
+		},
+		{
+			name:    "padded slug namespace is rejected",
+			profile: SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypeCompany, SlugNamespace: " gametable:space "},
+			wantErr: "leading or trailing whitespace",
+		},
+		{
+			name:    "blank creator role is rejected",
+			profile: SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypeCompany, CreatorRoles: []string{"  "}},
+			wantErr: "empty creator role",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.profile.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Validate() = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRegisterSpaceProfile(t *testing.T) {
+	t.Run("declared profile is readable from the config and the registry", func(t *testing.T) {
+		ResetSpaceProfilesForTest()
+		ext := NewExtension("gametable", RegisterSpaceProfile(venueProfile()))
+
+		got := ext.SpaceProfile()
+		if got == nil {
+			t.Fatal("SpaceProfile() = nil, want the declared profile")
+		}
+		if got.SpaceType != coretypes.SpaceTypeCompany {
+			t.Errorf("SpaceType = %q, want %q", got.SpaceType, coretypes.SpaceTypeCompany)
+		}
+
+		fromRegistry, ok := LookupSpaceProfile("gametable")
+		if !ok {
+			t.Fatal("LookupSpaceProfile() found nothing for a declared extension")
+		}
+		if fromRegistry.SlugNamespace != "gametable:space" {
+			t.Errorf("SlugNamespace = %q, want %q", fromRegistry.SlugNamespace, "gametable:space")
+		}
+	})
+
+	t.Run("an extension without a profile registers no spaces", func(t *testing.T) {
+		ResetSpaceProfilesForTest()
+		ext := NewExtension("schoolus")
+
+		if ext.SpaceProfile() != nil {
+			t.Error("SpaceProfile() is set for an extension that declared none")
+		}
+		if _, ok := LookupSpaceProfile("schoolus"); ok {
+			t.Error("LookupSpaceProfile() found a profile for an extension that declared none")
+		}
+	})
+
+	t.Run("redeclaring the same profile is a no-op", func(t *testing.T) {
+		// Building an extension twice — as tests and multiple composition roots
+		// do — must not be an error.
+		ResetSpaceProfilesForTest()
+		NewExtension("gametable", RegisterSpaceProfile(venueProfile()))
+		NewExtension("gametable", RegisterSpaceProfile(venueProfile()))
+
+		if _, ok := LookupSpaceProfile("gametable"); !ok {
+			t.Error("LookupSpaceProfile() lost the profile after a redeclaration")
+		}
+	})
+
+	t.Run("redeclaring a different profile panics", func(t *testing.T) {
+		// Two answers to "what is a venue Space?" is exactly the drift
+		// decision 0006 exists to end, so it fails loudly at startup.
+		ResetSpaceProfilesForTest()
+		NewExtension("gametable", RegisterSpaceProfile(venueProfile()))
+
+		defer func() {
+			if recover() == nil {
+				t.Error("redeclaring a different profile did not panic")
+			}
+		}()
+		NewExtension("gametable", RegisterSpaceProfile(SpaceRegistrationProfile{
+			SpaceType: coretypes.SpaceTypeClub,
+		}))
+	})
+
+	t.Run("an invalid profile panics", func(t *testing.T) {
+		ResetSpaceProfilesForTest()
+		defer func() {
+			if recover() == nil {
+				t.Error("an invalid profile did not panic")
+			}
+		}()
+		NewExtension("bad", RegisterSpaceProfile(SpaceRegistrationProfile{SpaceType: "nonsense"}))
+	})
+
+	t.Run("differing creator roles are a conflict", func(t *testing.T) {
+		ResetSpaceProfilesForTest()
+		NewExtension("x", RegisterSpaceProfile(SpaceRegistrationProfile{
+			SpaceType:    coretypes.SpaceTypeCompany,
+			CreatorRoles: []string{"member"},
+		}))
+		defer func() {
+			if recover() == nil {
+				t.Error("differing creator roles did not panic")
+			}
+		}()
+		NewExtension("x", RegisterSpaceProfile(SpaceRegistrationProfile{
+			SpaceType:    coretypes.SpaceTypeCompany,
+			CreatorRoles: []string{"member", "owner"},
+		}))
+	})
+
+	t.Run("a differing creator role value is a conflict", func(t *testing.T) {
+		ResetSpaceProfilesForTest()
+		NewExtension("y", RegisterSpaceProfile(SpaceRegistrationProfile{
+			SpaceType:    coretypes.SpaceTypeCompany,
+			CreatorRoles: []string{"member"},
+		}))
+		defer func() {
+			if recover() == nil {
+				t.Error("a differing creator role value did not panic")
+			}
+		}()
+		NewExtension("y", RegisterSpaceProfile(SpaceRegistrationProfile{
+			SpaceType:    coretypes.SpaceTypeCompany,
+			CreatorRoles: []string{"owner"},
+		}))
+	})
+}
+
+func TestRegisterableSpaceTypes(t *testing.T) {
+	ResetSpaceProfilesForTest()
+	if got := RegisterableSpaceTypes(); len(got) != 0 {
+		t.Fatalf("RegisterableSpaceTypes() = %v on an empty registry, want none", got)
+	}
+
+	NewExtension("gametable", RegisterSpaceProfile(SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypeCompany}))
+	NewExtension("communitycentrum", RegisterSpaceProfile(SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypeCompany}))
+	NewExtension("sneatclub", RegisterSpaceProfile(SpaceRegistrationProfile{SpaceType: coretypes.SpaceTypeClub}))
+
+	got := RegisterableSpaceTypes()
+	// Two products registering `company` yield one entry, sorted.
+	want := []coretypes.SpaceType{coretypes.SpaceTypeClub, coretypes.SpaceTypeCompany}
+	if len(got) != len(want) {
+		t.Fatalf("RegisterableSpaceTypes() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("RegisterableSpaceTypes() = %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
Implements the core of [sneat-specs decision 0006](https://github.com/sneat-co/sneat-specs/pull/13) — the reusable half of unified space registration. `RegisterSpace` itself lands in sneat-core-modules on top of this.

## Extensions declare, the platform executes

An extension now declares what registering a Space means for it, beside the extension id and known hosts it already declares:

```go
extension.NewExtension(ExtensionID,
    extension.RegisterKnownHosts(KnownHosts...),
    extension.RegisterSpaceProfile(spaceus.SpaceRegistrationProfile{
        SpaceType:     coretypes.SpaceTypeCompany, // staff are members
        SlugNamespace: "communitycentrum:space",
    }),
)
```

It is data, not behaviour — no callbacks — so "what does registering a venue do?" is answered by reading one struct literal. The shape follows eventius' `verticals` registry: adding a product means adding a row.

Profiles land in a process-wide registry at extension-construction time, which is what lets the platform ask *"which Space types can an extension register?"* without importing any extension. That is how the ordinary-space check stops being a hard-coded switch in a file no product owns — the thing that stranded NoticeBoard, whose `community-center` Spaces could never obtain a capability reservation.

Declaring two **different** profiles for one extension id panics at startup; the same profile twice is a no-op, so building an extension twice stays safe.

## Space types

- **`community-center` retired.** A centre's staff are members and its public are customers — which is what `company` already means — and the marker in `SpaceDbo.Modules` is what makes the Space a centre. Nothing depended on it in production: the NoticeBoard backend was never wired into sneat-go. Assetus had independently reached for the same concept and spelled it `community`, which is the drift decision 0006 records.
- **`space` no longer issued**, but still valid so existing records read. Not marked `Deprecated:` on purpose — the tests covering legacy records must keep naming it without tripping staticcheck.
- `company` and `club` gained doc comments stating the membership rule, since that is now the thing that picks between them.

## Verification

`gofmt -l .` clean · `go build ./...` · `go test ./...` all passing · `golangci-lint run ./...` — **0 issues**

New tests cover profile validation (including that `system`, `spot` and `personal` cannot be registered by an extension), registry lookup, the redeclaration conflict, and `RegisterableSpaceTypes` deduplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9oT1WTX24siFfAq1sv6gJ