### PR TITLE
Read-tolerate legacy space types: canonicalize private → personal

### DIFF
--- a/coretypes/space_type.go
+++ b/coretypes/space_type.go
@@ -135,3 +135,28 @@ func IsValidSpaceType(v SpaceType) bool {
 		return false
 	}
 }
+
+// legacySpaceTypeAliases maps space-type values that were once written to
+// records but have since been renamed. Stored data outlives enums: a user
+// record from 2025 carries a space brief of type "private" (renamed to
+// "personal"), and rejecting it on load bricks every flow that runs through a
+// user worker — including registration, whose audience is the least likely to
+// have pristine records.
+//
+// The map is for READ tolerance only: request validation stays strict, so no
+// new record is ever written with a legacy value.
+var legacySpaceTypeAliases = map[SpaceType]SpaceType{
+	"private": SpaceTypePersonal,
+}
+
+// CanonicalSpaceType maps a legacy stored space-type value to its current
+// name, and returns any other value unchanged. Callers validating STORED data
+// should check IsValidSpaceType(CanonicalSpaceType(v)); callers validating
+// REQUESTS should keep calling IsValidSpaceType(v) directly, so the legacy
+// names stay unwritable.
+func CanonicalSpaceType(v SpaceType) SpaceType {
+	if canonical, ok := legacySpaceTypeAliases[v]; ok {
+		return canonical
+	}
+	return v
+}

--- a/coretypes/space_type_test.go
+++ b/coretypes/space_type_test.go
@@ -225,3 +225,24 @@ func TestWeakSpaceRef(t *testing.T) {
 		})
 	}
 }
+
+func TestCanonicalSpaceType(t *testing.T) {
+	// The legacy "private" (renamed to "personal") must validate as stored
+	// data but never as a request value.
+	if got := CanonicalSpaceType("private"); got != SpaceTypePersonal {
+		t.Errorf("CanonicalSpaceType(private) = %q, want %q", got, SpaceTypePersonal)
+	}
+	if !IsValidSpaceType(CanonicalSpaceType("private")) {
+		t.Error("stored-data validation must accept legacy private")
+	}
+	if IsValidSpaceType("private") {
+		t.Error("request validation must keep rejecting legacy private")
+	}
+	// Modern values pass through unchanged.
+	if got := CanonicalSpaceType(SpaceTypeClub); got != SpaceTypeClub {
+		t.Errorf("CanonicalSpaceType(club) = %q, want %q", got, SpaceTypeClub)
+	}
+	if got := CanonicalSpaceType("nonsense"); got != "nonsense" {
+		t.Errorf("CanonicalSpaceType(nonsense) = %q, want unchanged", got)
+	}
+}


### PR DESCRIPTION
A founder-era user record carries a space brief of type `private` — renamed to `personal` long ago. Strict validation on **load** bricks every user-worker flow for such accounts; it surfaced in production as `user record loaded from DB is not valid: unknown space type` when registering a club.

`CanonicalSpaceType` maps legacy stored values to current names. Stored-data validators check `IsValidSpaceType(CanonicalSpaceType(v))`; request validation keeps calling `IsValidSpaceType` directly, so legacy names stay unwritable. Consumed by sneat-core-modules (user + space brief validators) in the follow-up PR.

Verification: build, tests (new `TestCanonicalSpaceType` covers stored-tolerant vs request-strict), lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9oT1WTX24siFfAq1sv6gJ