### PR TITLE
Add SpaceTypeTeam for child spaces

### DIFF
--- a/coretypes/space_type.go
+++ b/coretypes/space_type.go
@@ -53,6 +53,13 @@ const (
 	// subscriptions, not members; moderators may become members in a later
 	// phase.
 	SpaceTypeSpot SpaceType = "spot"
+
+	// SpaceTypeTeam is a child Space of an organisation Space — a club's squad
+	// ("Girls U14"), created via create_child_space and never registered as a
+	// vendor Space in its own right. It always carries ParentSpaceID; the
+	// parent's type says how the organisation's membership works, the team
+	// type says this Space is a subdivision of it.
+	SpaceTypeTeam SpaceType = "team"
 )
 
 // SpotSpaceIDPrefix is the reserved prefix used by SpotSpaceID to construct
@@ -129,7 +136,7 @@ func NewWeakSpaceRef(spaceType SpaceType) SpaceRef {
 // IsValidSpaceType checks if space has a valid/known type
 func IsValidSpaceType(v SpaceType) bool {
 	switch v {
-	case SpaceTypePersonal, SpaceTypeFamily, SpaceTypeGroup, SpaceTypeCompany, SpaceTypeSpace, SpaceTypeClub, SpaceTypeSystem, SpaceTypeSpot:
+	case SpaceTypePersonal, SpaceTypeFamily, SpaceTypeGroup, SpaceTypeCompany, SpaceTypeSpace, SpaceTypeClub, SpaceTypeSystem, SpaceTypeSpot, SpaceTypeTeam:
 		return true
 	default:
 		return false

--- a/coretypes/space_type_test.go
+++ b/coretypes/space_type_test.go
@@ -19,6 +19,7 @@ func TestIsValidSpaceType(t *testing.T) {
 		{"private-now-invalid", args{"private"}, false},
 		{"SpaceTypeSystem", args{SpaceTypeSystem}, true},
 		{"SpaceTypeSpot", args{SpaceTypeSpot}, true},
+		{"SpaceTypeTeam", args{SpaceTypeTeam}, true},
 		{"EmptySpaceType", args{""}, false},
 		{"InvalidSpaceType", args{"Foo"}, false},
 	}


### PR DESCRIPTION
A club's squad ("Girls U14") gets its own space type instead of inheriting the parent's `club`. The type shows in URLs (`/space/team/...`) and user-record briefs, drives instant UI branching, and lets clubs-only listings exclude teams naturally — a team rendering as `/space/club/...` confused the founder in live testing on sneat.club.

Teams always carry `ParentSpaceID` and are created only via `create_child_space` (sneat-core-modules follow-up switches the child type to `team` and guards `create_space` against minting orphan teams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9oT1WTX24siFfAq1sv6gJ