### PR TITLE
Add fleet-canonical in-memory test-DB helper; bump dalgo to v0.74.0

### DIFF
--- a/facade/get_sneat_db_test.go
+++ b/facade/get_sneat_db_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/dal-go/dalgo/dal"
 )
 
+// This file is package facade (an internal test file), and
+// sneatcoretesting.NewInMemoryTestDB itself imports facade (for
+// facade.WithSneatDB) — so importing sneatcoretesting here would be an import
+// cycle. Call dalgo2memory.New(dalgo2memory.FirestoreProfile(), ...) directly
+// instead; that is the same Firestore-profile choice NewInMemoryTestDB makes,
+// just inlined for this one package's tests.
+
 func TestGetDatabase(t *testing.T) {
 	ctx := context.Background()
 	defer mustPanicWithErrNotInitialized(t)
@@ -23,8 +30,8 @@ func TestGetDatabase(t *testing.T) {
 
 func TestWithSneatDB_IsolatesContexts(t *testing.T) {
 	t.Parallel()
-	db1 := dalgo2memory.NewDB()
-	db2 := dalgo2memory.NewDB()
+	db1 := dalgo2memory.New(dalgo2memory.FirestoreProfile())
+	db2 := dalgo2memory.New(dalgo2memory.FirestoreProfile())
 	ctx1 := WithSneatDB(context.Background(), db1)
 	ctx2 := WithSneatDB(context.Background(), db2)
 
@@ -63,7 +70,7 @@ func TestDefaultSneatDBProviderConfiguration(t *testing.T) {
 	defaultSneatDBProviderMu.RUnlock()
 	t.Cleanup(func() { SetDefaultSneatDBProvider(previous) })
 
-	db := dalgo2memory.NewDB()
+	db := dalgo2memory.New(dalgo2memory.FirestoreProfile())
 	SetDefaultSneatDBProvider(func(context.Context) (dal.DB, error) {
 		return db, nil
 	})

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,12 @@ module github.com/sneat-co/sneat-go-core
 
 // https://github.com/sneat-co/sneat-go-core/actions
 
-go 1.26.0
-
-toolchain go1.27.0
+go 1.27.0
 
 require (
 	github.com/crediterra/money v0.3.5
-	github.com/dal-go/dalgo v0.66.0
+	github.com/dal-go/dalgo v0.74.0
+	github.com/dal-go/record v0.1.3
 	github.com/stretchr/testify v1.12.1
 	github.com/strongo/analytics v0.2.5
 	github.com/strongo/delaying v0.2.3
@@ -21,14 +20,12 @@ require (
 	golang.org/x/text v0.22.0
 )
 
-require go.yaml.in/yaml/v3 v3.0.5 // indirect
-
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.25.0 // indirect
 	github.com/alexsergivan/transliterator v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.6 // indirect
-	github.com/dal-go/record v0.1.3
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/strongo/decimal v0.1.2 // indirect
 	github.com/strongo/random v0.0.1 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/bits-and-blooms/bitset v1.24.6 h1:qcrftZUVBIwfs+m+nhoCBAPT+ZPZZjti8Sb
 github.com/bits-and-blooms/bitset v1.24.6/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/crediterra/money v0.3.5 h1:H59COTzKEtRbl8Wlr2tNYWnBkoMOdOrEPVhGYez+VGU=
 github.com/crediterra/money v0.3.5/go.mod h1:0BT7dzPk4Wv+Wi8J6sxlFbCknYioLWVVQM4ciMJh6TI=
-github.com/dal-go/dalgo v0.66.0 h1:gesurCrEK57wiTCaaw8PhGM/Y7wViXaXPxcF1Td4AeU=
-github.com/dal-go/dalgo v0.66.0/go.mod h1:2siY9rsHk+pQnZcJhac2B4QM9gQYbjzV+TJAYEUh6Ng=
+github.com/dal-go/dalgo v0.74.0 h1:YGfpZCIat8/5L3DXhGNoNSssZoLH0kYIPBWiEeDNlYA=
+github.com/dal-go/dalgo v0.74.0/go.mod h1:3vwKKVCGf8gQoHrMFkEAj2JxbGt5th04Oi2kSdDTGd8=
 github.com/dal-go/record v0.1.3 h1:K85k/kSX08lTefMiMmPpC12nmCY2TVJk7+ZyC5PD9XU=
 github.com/dal-go/record v0.1.3/go.mod h1:quwsVJTT0f6y3Mhx+yHpTobY7luX1M6kyO6fdJ/AFYE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/slugs/claim_test.go
+++ b/slugs/claim_test.go
@@ -44,10 +44,11 @@ func TestClaim_SecondClaimIsRefused(t *testing.T) {
 // slug and then fails before commit should roll back, leaving no claim
 // document — the slug free.
 //
-// This is proved against dalgo2memory's WithOptimisticConcurrency() mode
-// (dal-go/dalgo v0.65.0): a transaction created in that mode buffers every
-// read and write locally and never touches the shared engine until commit,
-// which runs only if the callback returns nil (see
+// This is proved against sneatcoretesting.NewInMemoryTestDB's
+// dalgo2memory.FirestoreProfile() (dal-go/dalgo v0.74.0): a transaction
+// created against that profile buffers every read and write locally and
+// never touches the shared engine until commit, which runs only if the
+// callback returns nil (see
 // runOptimisticReadwriteTransaction in adapters/dalgo2memory/optimistic.go).
 // A callback that returns an error short-circuits before commit is even
 // attempted, so Claim's tx.Insert — buffered, never applied — is discarded
@@ -55,7 +56,7 @@ func TestClaim_SecondClaimIsRefused(t *testing.T) {
 // not merely "the caller saw an error": the assertion below reads the slug
 // back from the database afterwards to confirm nothing was ever written.
 func TestClaim_RollbackLeavesNoOrphanClaim(t *testing.T) {
-	db := dalgo2memory.NewDB(dalgo2memory.WithOptimisticConcurrency())
+	db := sneatcoretesting.NewInMemoryTestDB()
 	ctx := context.Background()
 
 	simulatedErr := errors.New("simulated failure writing the caller's own record")
@@ -204,7 +205,7 @@ func TestClaim_ReservedSlugIsRefusedDistinctly(t *testing.T) {
 // undefined collections, so the insert is rejected by the collection guard
 // long before anything could be duplicated.
 func TestClaim_NonDuplicateFailureIsNotReportedAsTaken(t *testing.T) {
-	db := dalgo2memory.NewDB(dalgo2memory.WithSchema(false))
+	db := sneatcoretesting.NewInMemoryTestDB(dalgo2memory.WithSchema(false))
 	ctx := context.Background()
 
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {

--- a/slugs/concurrency_test.go
+++ b/slugs/concurrency_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dal-go/dalgo/adapters/dalgo2memory"
 	"github.com/dal-go/dalgo/dal"
 	"github.com/sneat-co/sneat-go-core/slugs"
+	"github.com/sneat-co/sneat-go-core/sneatcoretesting"
 )
 
 // TestClaim_ConcurrentClaimsYieldOneWinner verifies
@@ -14,10 +15,12 @@ import (
 // the same slug must settle with exactly one commit, and no observer can
 // ever see both holding the claim.
 //
-// This is proved against dalgo2memory's WithOptimisticConcurrency() mode
-// (dal-go/dalgo v0.65.0): unlike the package's default mode, that mode lets
-// two RunReadwriteTransaction calls genuinely interleave — each buffers its
-// reads and writes locally and touches no shared storage until commit, where
+// This is proved against sneatcoretesting.NewInMemoryTestDB's
+// dalgo2memory.FirestoreProfile() (dal-go/dalgo v0.74.0), which carries
+// optimistic concurrency as part of its Firestore-faithful bundle: unlike a
+// single-writer mode, that mode lets two RunReadwriteTransaction calls
+// genuinely interleave — each buffers its reads and writes locally and
+// touches no shared storage until commit, where
 // it is validated against every key it touched. Claim's only operation is a
 // single tx.Insert, so racing it against itself races Insert's own
 // touch-then-stage step; forcing both transactions past that step (via
@@ -32,7 +35,7 @@ import (
 // a paused transaction callback holds no lock while it waits — see that
 // test's doc comment for the full argument.
 func TestClaim_ConcurrentClaimsYieldOneWinner(t *testing.T) {
-	db := dalgo2memory.NewDB(dalgo2memory.WithOptimisticConcurrency())
+	db := sneatcoretesting.NewInMemoryTestDB()
 	ctx := context.Background()
 
 	const attempts = 2

--- a/slugs/rename_test.go
+++ b/slugs/rename_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dal-go/dalgo/adapters/dalgo2memory"
 	"github.com/dal-go/dalgo/dal"
 	"github.com/sneat-co/sneat-go-core/slugs"
 	"github.com/sneat-co/sneat-go-core/sneatcoretesting"
@@ -108,14 +107,14 @@ func TestRename_NewSlugTakenLeavesOldUntouched(t *testing.T) {
 //
 // This is proved the same way as TestClaim_RollbackLeavesNoOrphanClaim in
 // claim_test.go (see that test's comment for the full explanation):
-// dalgo2memory's WithOptimisticConcurrency() mode (dal-go/dalgo v0.65.0)
-// buffers both of Rename's writes — the new slug's Insert and the old
-// slug's tombstoning Update — locally, and never reaches the shared engine
-// unless the callback returns nil. Returning an error after both writes
-// discards both together, proving the two really do rise and fall as one
-// operation rather than each being independently durable.
+// sneatcoretesting.NewInMemoryTestDB's dalgo2memory.FirestoreProfile()
+// (dal-go/dalgo v0.74.0) buffers both of Rename's writes — the new slug's
+// Insert and the old slug's tombstoning Update — locally, and never reaches
+// the shared engine unless the callback returns nil. Returning an error
+// after both writes discards both together, proving the two really do rise
+// and fall as one operation rather than each being independently durable.
 func TestRename_IsAtomic(t *testing.T) {
-	db := dalgo2memory.NewDB(dalgo2memory.WithOptimisticConcurrency())
+	db := sneatcoretesting.NewInMemoryTestDB()
 	ctx := context.Background()
 
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {

--- a/sneatcoretesting/memory_db.go
+++ b/sneatcoretesting/memory_db.go
@@ -11,23 +11,38 @@ import (
 	"github.com/sneat-co/sneat-go-core/facade"
 )
 
+// NewInMemoryTestDB is the fleet's single place that names Firestore as the
+// backend an in-memory test database emulates. dal-go/dalgo v0.74.0 made the
+// emulated backend an explicit, compile-enforced parameter of
+// dalgo2memory.New — dalgo itself is platform-independent, with adapters for
+// Firestore, Datastore, MySQL, Postgres, SQLite and more, so no single
+// vendor's transaction semantics can be a neutral default. The Sneat fleet's
+// production backend IS Firestore, so its tests must exercise Firestore's
+// transaction semantics: genuine contention between concurrent read-write
+// transactions, snapshot reads, bounded auto-retry, and strict
+// read-before-write ordering within a transaction. Call sites elsewhere in
+// the fleet should use this helper instead of choosing a dalgo2memory profile
+// ad hoc — that keeps the "our production backend is Firestore" decision made
+// once, here, rather than repeated (and potentially gotten wrong) at every
+// call site in every repo.
+func NewInMemoryTestDB(options ...dalgo2memory.Option) dal.DB {
+	return dalgo2memory.New(dalgo2memory.FirestoreProfile(), options...)
+}
+
 // NewMemoryDB creates a strict in-memory database for Sneat tests.
 //
 // The strict transaction mode mirrors Firestore: a transaction cannot read
 // after its first write. Tests should use this instead of constructing a
 // dalgo2memory database directly.
 func NewMemoryDB() dal.DB {
-	return dalgo2memory.NewDB(dalgo2memory.WithNoReadsAfterWritesInTransaction())
+	return NewInMemoryTestDB()
 }
 
 // NewStrictSchemaMemoryDB creates an empty strict-schema in-memory database
 // for tests that must reject accesses to undeclared collections. It retains the
 // Firestore-compatible transaction ordering enforced by NewMemoryDB.
 func NewStrictSchemaMemoryDB() dal.DB {
-	return dalgo2memory.NewDB(
-		dalgo2memory.WithNoReadsAfterWritesInTransaction(),
-		dalgo2memory.WithSchema(false),
-	)
+	return NewInMemoryTestDB(dalgo2memory.WithSchema(false))
 }
 
 // ContextWithMemoryDB returns a child context with a new strict in-memory

--- a/sneatcoretesting/memory_db_test.go
+++ b/sneatcoretesting/memory_db_test.go
@@ -40,6 +40,21 @@ func TestSetupMemoryDB_ParallelIsolation(t *testing.T) {
 	}
 }
 
+func TestNewInMemoryTestDB_RejectsReadsAfterWrites(t *testing.T) {
+	t.Parallel()
+	db := sneatcoretesting.NewInMemoryTestDB()
+	key := record.NewKeyWithID("records", "firestore-ordering")
+	err := db.RunReadwriteTransaction(context.Background(), func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, record.NewRecordWithData(key, new(struct{}))); err != nil {
+			return err
+		}
+		return tx.Get(ctx, record.NewRecordWithData(key, new(struct{})))
+	})
+	if !errors.Is(err, dalgo2memory.ErrReadAfterWriteInTransaction) {
+		t.Fatalf("NewInMemoryTestDB read-after-write error = %v, want %v (Firestore's transaction ordering)", err, dalgo2memory.ErrReadAfterWriteInTransaction)
+	}
+}
+
 func TestNewMemoryDB_RejectsReadsAfterWrites(t *testing.T) {
 	t.Parallel()
 	db := sneatcoretesting.NewMemoryDB()


### PR DESCRIPTION
## Summary
- dal-go/dalgo v0.74.0 made the emulated backend an explicit, compile-enforced parameter of `dalgo2memory.New(profile, options...)`; `dalgo2memory.NewDB(...)` is now deprecated (Firestore-defaulting alias, removal scheduled).
- Adds `sneatcoretesting.NewInMemoryTestDB(options ...dalgo2memory.Option) dal.DB`, the fleet's single place that names Firestore as the backend our in-memory tests emulate — matching the Sneat fleet's actual Firestore production backend. `NewMemoryDB` and `NewStrictSchemaMemoryDB` now build on it.
- Migrates all 9 `dalgo2memory.NewDB(` call sites in this repo to the new helper, except `facade/get_sneat_db_test.go` (an internal `package facade` test file), which calls `dalgo2memory.New(dalgo2memory.FirestoreProfile())` directly — importing `sneatcoretesting` there would create an import cycle (`sneatcoretesting` imports `facade`). Noted in a comment at that call site.
- Adds `TestNewInMemoryTestDB_RejectsReadsAfterWrites`, proving the helper enforces Firestore's transaction ordering (`ErrReadAfterWriteInTransaction` on a read after a write inside a rw transaction).
- `go.mod`'s `go` directive moves to `1.27.0` (dalgo v0.74.0's own go.mod requires it).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./...` (all packages pass, including `convospec` nested module)
- [x] `staticcheck ./...` clean (no SA1019 deprecation findings)
- [x] `gofmt -l .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx