### PR TITLE
build: declare go 1.26.0 with toolchain go1.27.0; dalgo v0.74.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,13 @@ module github.com/sneat-co/sneat-go-core
 
 // https://github.com/sneat-co/sneat-go-core/actions
 
-go 1.27.0
+go 1.26.0
+
+toolchain go1.27.0
 
 require (
 	github.com/crediterra/money v0.3.5
-	github.com/dal-go/dalgo v0.74.0
+	github.com/dal-go/dalgo v0.74.1
 	github.com/dal-go/record v0.1.3
 	github.com/stretchr/testify v1.12.1
 	github.com/strongo/analytics v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/bits-and-blooms/bitset v1.24.6 h1:qcrftZUVBIwfs+m+nhoCBAPT+ZPZZjti8Sb
 github.com/bits-and-blooms/bitset v1.24.6/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/crediterra/money v0.3.5 h1:H59COTzKEtRbl8Wlr2tNYWnBkoMOdOrEPVhGYez+VGU=
 github.com/crediterra/money v0.3.5/go.mod h1:0BT7dzPk4Wv+Wi8J6sxlFbCknYioLWVVQM4ciMJh6TI=
-github.com/dal-go/dalgo v0.74.0 h1:YGfpZCIat8/5L3DXhGNoNSssZoLH0kYIPBWiEeDNlYA=
-github.com/dal-go/dalgo v0.74.0/go.mod h1:3vwKKVCGf8gQoHrMFkEAj2JxbGt5th04Oi2kSdDTGd8=
+github.com/dal-go/dalgo v0.74.1 h1:ec5dK6CK7Rf+3kOehjmLGsAwk3UHoSsV9k5ZtPXylgA=
+github.com/dal-go/dalgo v0.74.1/go.mod h1:O8cUbJZY4d44TJdZF169QZtQdwtIT6H3g70fCKrV7jM=
 github.com/dal-go/record v0.1.3 h1:K85k/kSX08lTefMiMmPpC12nmCY2TVJk7+ZyC5PD9XU=
 github.com/dal-go/record v0.1.3/go.mod h1:quwsVJTT0f6y3Mhx+yHpTobY7luX1M6kyO6fdJ/AFYE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Restores the founder convention — declare `go 1.26.0`, set `toolchain go1.27.0` — now that `dal-go/dalgo` v0.74.1 lowers its own directive to 1.26.0 and stops forcing consumers to 1.27.

## Why the directive was stuck at 1.27.0

Go requires every module to declare at least its dependencies `go` directive. dalgo v0.74.0 declared `go 1.27.0` incidentally (its real floor is 1.24.0), so `go mod tidy` here rewrote any lower value straight back. dal-go/dalgo#130 fixed that at the source; this PR takes v0.74.1 and restores the convention.

## Side effect worth naming

GitHub CodeQL **default setup** builds on a hosted runner with an older preinstalled Go and `GOTOOLCHAIN=local`, so it cannot build any `go >= 1.27.0` module — its `Analyze (go)` job failed across repos that took the ratchet (listus, sportius, sneat-cli, sneat-mod-template). That surface is configured in repository settings rather than a workflow file, so it was not fixable per-repo; lowering the directive is what actually unblocks it.

## Verification

Under a Go 1.26 toolchain (`GOTOOLCHAIN=go1.26.0`): `go build ./...` and `go vet ./...` clean, `go test -count=1 ./...` green — 27 packages in the root module, plus the nested `convospec` module. `go mod tidy` leaves the directive at 1.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx