### PR TITLE
docs: document facade.GetSneatDB var-to-func migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,29 @@ We build with our own tooling:
 - **[cover100.dev](https://cover100.dev)** — drive toward 100% test coverage
 - **[DataTug](https://datatug.io)** — query & explore data
 <!-- /dev-approach -->
+
+## Migration notes
+
+### `facade.GetSneatDB` is a func, not a var (since v0.60.3 of sneat-co/sneat-go-core)
+
+Before v0.60.3, `facade.GetSneatDB` was a package-level `var` that tests
+reassigned directly:
+
+```go
+facade.GetSneatDB = func(ctx context.Context) (dal.DB, error) { ... } // no longer compiles
+```
+
+Since v0.60.3 it is a plain `func` and can no longer be reassigned. Tests must
+inject a DB through the context instead:
+
+```go
+ctx = facade.WithSneatDB(ctx, db) // or facade.WithSneatDBProvider(ctx, provider)
+```
+
+A call site that instead did `var getSneatDB = facade.GetSneatDB` — binding
+the function *value* to a local and reassigning the local in tests — keeps
+compiling either way, because that pattern doesn't care whether the upstream
+symbol is a var or a func.
+
+See the doc comments on `facade.GetSneatDB` / `facade.WithSneatDB` in
+[`facade/get_sneat_db.go`](facade/get_sneat_db.go) for details.

--- a/facade/get_sneat_db.go
+++ b/facade/get_sneat_db.go
@@ -21,6 +21,14 @@ var (
 
 // GetSneatDB returns a context override when one is present, otherwise it uses
 // the default provider configured by the application at startup.
+//
+// Migration note: before v0.60.3, GetSneatDB was a package-level var
+// (func(ctx context.Context) (dal.DB, error)) that tests reassigned directly:
+//
+//	facade.GetSneatDB = func(ctx context.Context) (dal.DB, error) { ... } // no longer compiles
+//
+// Since v0.60.3 it is a plain func and cannot be reassigned. Tests must inject
+// a DB through the context instead, via WithSneatDB or WithSneatDBProvider.
 func GetSneatDB(ctx context.Context) (dal.DB, error) {
 	if provider, ok := ctx.Value(contextDBKey).(SneatDBProvider); ok {
 		return provider(ctx)
@@ -34,6 +42,10 @@ func GetSneatDB(ctx context.Context) (dal.DB, error) {
 
 // WithSneatDB returns a child context that resolves db through GetSneatDB.
 // This is useful for request-scoped database selection and parallel tests.
+//
+// This is the replacement for the pre-v0.60.3 pattern of reassigning the
+// package-level facade.GetSneatDB var directly (see the migration note on
+// GetSneatDB above).
 func WithSneatDB(ctx context.Context, db dal.DB) context.Context {
 	if db == nil {
 		panic("facade.WithSneatDB: nil DB")


### PR DESCRIPTION
## Summary
- `facade.GetSneatDB` stopped being a package-level `var` and became a plain `func` in commit 7fd15b1 (refactor: isolate DB dependencies for parallel tests, #108), first shipped in **v0.60.3** — tests that reassigned it directly no longer compile.
- Documents the `WithSneatDB` / `WithSneatDBProvider` context-injection replacement as a doc comment on `GetSneatDB`/`WithSneatDB` in `facade/get_sneat_db.go`, plus a "Migration notes" section in `README.md` (this repo has no `AGENTS.md`, so README is the existing convention).
- Documentation only — no behavior change (verified `go build ./... && go vet ./facade/...`).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./facade/...`
- [x] Full test suite ran clean on push (pre-push hook)

https://claude.ai/code/session_01KFsyYhYi9h9Am1JbAMxuhv