### PR TITLE
feat(facade): add SpaceAccessAuthorizedByCaller helper

### DIFF
--- a/facade/context_with_user.go
+++ b/facade/context_with_user.go
@@ -62,6 +62,51 @@ func NewContextWithUserAndAnalytics(ctx context.Context, userCtx UserContext, ua
 	return ctxWithUser
 }
 
+// spaceAccessAuthorizedByCallerContext is the UserContext behind
+// SpaceAccessAuthorizedByCaller: a deliberately empty user ID that opts the
+// current DAL transaction out of dal4spaceus's space-membership gate. See
+// SpaceAccessAuthorizedByCaller for the full contract before using this type
+// directly.
+type spaceAccessAuthorizedByCallerContext struct{}
+
+func (spaceAccessAuthorizedByCallerContext) GetUserID() string { return "" }
+
+// SpaceAccessAuthorizedByCaller returns a facade.ContextWithUser whose
+// GetUserID() is deliberately empty, wrapping ctx unchanged in every other
+// respect.
+//
+// dal4spaceus's space-membership gate only runs when GetUserID() is
+// non-empty: an empty user ID is that gate's deliberate opt-out, not a
+// missing check. Running a space worker under the context returned here
+// means the DAL's own "is this caller a member of the space" check will NOT
+// run for that transaction.
+//
+// This is NOT anonymous or unauthenticated access. Call it only after the
+// caller has already authorised the operation by its own proof -- because
+// the DAL is intentionally trusting the facade layer to have done that
+// check already, not because no check is needed. The known legitimate uses
+// are:
+//
+//   - a maintenance / fixer job running with no user at all;
+//   - a user joining a space by invite, who by definition is not yet a
+//     member and would otherwise fail the ordinary membership gate before
+//     the invite proof (ID + PIN, or equivalent) is even checked;
+//   - moderation, such as removing a user from a space for spam, performed
+//     by an actor who is not themselves a member of that space.
+//
+// The caller MUST keep its own authenticated user ID (or "no user", for a
+// maintenance job) in a separate variable and keep using it for business
+// logic -- audit trails, "who did this", any authorisation decision made
+// above the DAL. This helper only neutralises the DAL's membership check;
+// it does not erase who is actually acting.
+//
+// Using this to skip an authorisation you have not actually performed is a
+// security bug: it silences the DAL's last line of defense without
+// supplying the proof that defense exists to enforce.
+func SpaceAccessAuthorizedByCaller(ctx context.Context) ContextWithUser {
+	return NewContextWithUser(ctx, spaceAccessAuthorizedByCallerContext{})
+}
+
 func GetUserContext(ctx context.Context) UserContext {
 	return ctx.Value(&userContextKey).(UserContext)
 }

--- a/facade/context_with_user_test.go
+++ b/facade/context_with_user_test.go
@@ -33,3 +33,49 @@ func Test_contextWithUser_User(t *testing.T) {
 		t.Error("ctx.User() != userCtx")
 	}
 }
+
+func TestSpaceAccessAuthorizedByCaller(t *testing.T) {
+	type ctxKey struct{}
+	base := context.WithValue(context.Background(), ctxKey{}, "preserved")
+
+	got := SpaceAccessAuthorizedByCaller(base)
+
+	if got == nil {
+		t.Fatal("SpaceAccessAuthorizedByCaller returned nil")
+	}
+	if userID := got.User().GetUserID(); userID != "" {
+		t.Errorf("got.User().GetUserID() = %q, want empty string", userID)
+	}
+	if v := got.Value(ctxKey{}); v != "preserved" {
+		t.Errorf("got.Value(ctxKey{}) = %v, want %q -- the base context must be preserved", v, "preserved")
+	}
+}
+
+// TestSpaceAccessAuthorizedByCaller_SpaceWorkerSkipsMembershipGate documents,
+// at the facade level, the contract that dal4spaceus relies on: a
+// facade.UserContext with GetUserID() == "" is what a space worker's
+// membership gate treats as "do not check membership" -- exactly what
+// SpaceAccessAuthorizedByCaller returns. The membership gate itself lives in
+// sneat-core-modules (spaceus/dal4spaceus), which imports this package, so
+// the end-to-end behaviour is covered there
+// (see dal4spaceus.TestSpaceWorkerParams_GetRecords); this test pins the
+// half of the contract that belongs to sneat-go-core: the returned user
+// context's ID is empty and stays empty regardless of the wrapped context.
+func TestSpaceAccessAuthorizedByCaller_SpaceWorkerSkipsMembershipGate(t *testing.T) {
+	// A stand-in "space worker membership gate" shaped exactly like
+	// dal4spaceus's real one: it only enforces membership when GetUserID()
+	// is non-empty.
+	membershipGateWouldRun := func(userCtx UserContext) bool {
+		return userCtx.GetUserID() != ""
+	}
+
+	authenticated := NewContextWithUserID(context.Background(), "user-1")
+	if !membershipGateWouldRun(authenticated.User()) {
+		t.Fatal("sanity check failed: an authenticated context must still trip the membership gate")
+	}
+
+	neutral := SpaceAccessAuthorizedByCaller(context.Background())
+	if membershipGateWouldRun(neutral.User()) {
+		t.Error("SpaceAccessAuthorizedByCaller's context must not trip the space worker's membership gate")
+	}
+}


### PR DESCRIPTION
## Summary
- Names and documents, as an exported helper, the previously undocumented convention where a `facade.UserContext` with an empty `GetUserID()` opts a transaction out of `dal4spaceus`'s space-membership gate.
- Today the pattern exists only as an unexported anonymous type in `sneat-core-modules` (`invitus/facade4invitus/claim_personal_invite.go`), discoverable only by reading that one file. `facade.SpaceAccessAuthorizedByCaller(ctx)` gives it a name and a doc comment stating the contract, the three legitimate uses, and that using it to skip a check you have not actually performed is a security bug.
- Follow-up (separate PR, `sneat-core-modules`): migrate the `invitus` call site to this helper once this is released.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./facade/...`
- [x] `go test ./...` (all packages pass)
- [x] `go mod tidy` produces no diff

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_01KFsyYhYi9h9Am1JbAMxuhv